### PR TITLE
[RFC] Fixes for vagrant

### DIFF
--- a/prepare-local/README.md
+++ b/prepare-local/README.md
@@ -45,6 +45,10 @@ Run the following commands:
     $ chmod 600 private-key
     $ ansible-playbook provisioning.yml
 
+Restart your VMs to force the Ansible configurations to be enabled:
+
+    $ vagrant halt; vagrant up
+
 And that's it! Now you should be able to ssh on `node1` using:
 
     $ ssh vagrant@10.10.10.10 -i private-key

--- a/prepare-local/README.md
+++ b/prepare-local/README.md
@@ -95,3 +95,11 @@ been provided that can be run on node1 to fully configure this:
   `known_hosts` file with:
 
       $ ssh-keygen -f "~/.ssh/known_hosts" -R 10.10.10.10 -R 10.10.10.20 -R 10.10.10.30 -R 10.10.10.40 -R 10.10.10.50
+
+- Depending on system load, Ansible may have difficulties configuring all
+  machines.  It is possible that one or more of the nodes will stop responding
+  before Ansible times out and removes it from the configuration.  If this happens
+  you will need to rerun the ansible-playbook command.  It is advisable to restart
+  your VMs in this situation
+  
+      $ vagrant halt; vagrant up

--- a/prepare-local/README.md
+++ b/prepare-local/README.md
@@ -62,7 +62,17 @@ The source code of this repo will be mounted at `~/orchestration-workshop`
 will reflect inside the instance.
 
 
-## 3. Possible problems and solutions
+## 3. Setup docker-machine
+
+In the normal cloud-based setup fromthe prepare-vms directory, the 5 nodes
+are automatically added to docker-machine for easy access between the nodes.
+In this setup we need to manually configure docker-machine.  A script has
+been provided that can be run on node1 to fully configure this:
+
+    $ ssh vagrant@10.10.10.10 -i private-key setup-docker-machine.sh
+
+
+## 4. Possible problems and solutions
 
 - Depending on the Vagrant version, `sudo apt-get install bsdtar` may be needed
 

--- a/prepare-local/Vagrantfile
+++ b/prepare-local/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure('2') do |config|
     unless Vagrant.has_plugin?(plugin_name)
       puts "Vagrant [" + plugin_name + "] is required but is not installed\n" +
            "please check if you have the plugin with the following command:\n" +
-           "    $ vagrand plugin list\n" +
+           "    $ vagrant plugin list\n" +
            "If needed install the plugin:\n" +
            "    $ vagrant plugin install " + plugin_name + "\n"
       abort "Missing [" + plugin_name + "] plugin\n\n"

--- a/prepare-local/provisioning.yml
+++ b/prepare-local/provisioning.yml
@@ -24,7 +24,7 @@
 
     - name: installing dependencies
       apt:
-        name: apt-transport-https,ca-certificates,python-pip,tmux
+        name: apt-transport-https,ca-certificates,python-pip,tmux,httping
         state: present
         update_cache: true
 

--- a/prepare-local/provisioning.yml
+++ b/prepare-local/provisioning.yml
@@ -24,7 +24,7 @@
 
     - name: installing dependencies
       apt:
-        name: apt-transport-https,ca-certificates,python-pip,tmux,httping
+        name: apt-transport-https,ca-certificates,python-pip,tmux,httping,linux-image-extra-virtual
         state: present
         update_cache: true
 
@@ -115,6 +115,16 @@
       hostname:
         name: "{{ inventory_hostname }}"
 
+    - name: download and install docker-machine
+      get_url:
+        url:  https://github.com/docker/machine/releases/download/{{ item.docker_machine_version }}/docker-machine-{{ item.kernel_uname }}-{{ item.machine }}
+        dest: /usr/local/bin/docker-machine
+        mode: 0755
+      with_items:
+        - docker_machine_version: v0.8.0
+          kernel_uname: Linux
+          machine : x86_64
+
     - name: adjusting the /etc/hosts to the new hostname
       lineinfile:
         dest: /etc/hosts
@@ -129,4 +139,10 @@
         - regexp: '^127\.0\.1\.1'
           line: "127.0.1.1 {{ inventory_hostname }}"
 
-
+    - name: Copying the setup-docker-machine.sh script
+      copy:
+        src: setup-docker-machine.sh
+        dest: /home/vagrant/setup-docker-machine.sh
+        mode: 0755
+        group: root
+        owner: vagrant

--- a/prepare-local/setup-docker-machine.sh
+++ b/prepare-local/setup-docker-machine.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+/usr/local/bin/docker-machine create -d generic --generic-ip-address "10.10.10.20" --generic-ssh-user vagrant --generic-ssh-port 22 --generic-ssh-key /home/vagrant/private-key --generic-engine-port 55555 "node2"
+/usr/local/bin/docker-machine create -d generic --generic-ip-address "10.10.10.30" --generic-ssh-user vagrant --generic-ssh-port 22 --generic-ssh-key /home/vagrant/private-key --generic-engine-port 55555 "node3"
+/usr/local/bin/docker-machine create -d generic --generic-ip-address "10.10.10.40" --generic-ssh-user vagrant --generic-ssh-port 22 --generic-ssh-key /home/vagrant/private-key --generic-engine-port 55555 "node4"
+/usr/local/bin/docker-machine create -d generic --generic-ip-address "10.10.10.50" --generic-ssh-user vagrant --generic-ssh-port 22 --generic-ssh-key /home/vagrant/private-key --generic-engine-port 55555 "node5"


### PR DESCRIPTION
These are a few updates I needed to get the prepare-local setup with Vagrant working.  The main difference being that docker-machine was not installed or configured but it was referenced in the workshop slides.  This is not ideal as it requires the user to manually run the setup-docker-machine.sh script but it does, at least in my case, work.  I know virtually nothing about Ansible so there is likely a better mechanism to support this.

Also, for some reason, after running the provisioning, I need to "vagrant halt; vagrant up" to get the Docker daemon running and responding to the docker-machine commands.  Any idea why that would be needed?