### PR TITLE
Typo correction in detach mode?

### DIFF
--- a/slides/swarm/firstservice.md
+++ b/slides/swarm/firstservice.md
@@ -174,7 +174,7 @@ class: extra-details
 
   - great in headless scripts (where nobody's watching anyway)
 
-.warning[`--detach=false` does not complete *faster*. It just *doesn't wait* for completion.]
+.warning[`--detach=true` does not complete *faster*. It just *doesn't wait* for completion.]
 
 ---
 


### PR DESCRIPTION
While you wrote:
`--detach=false` does not complete *faster*. It just *doesn't wait* for completion.
I think you actually meant:
`--detach=TRUE` does not complete *faster*. It just *doesn't wait* for completion.