### PR TITLE
Remove port from 'docker swarm init' command

### DIFF
--- a/slides/swarm/creatingswarm.md
+++ b/slides/swarm/creatingswarm.md
@@ -71,7 +71,7 @@ Examples:
 
 ```bash
 docker swarm init --advertise-addr 10.0.9.2
-docker swarm init --advertise-addr eth0:7777
+docker swarm init --advertise-addr eth0
 ```
 
 ---


### PR DESCRIPTION
I think port 7777 should only be used when running 'docker swarm join...', not when running 'docker swarm init...'
For the init step you just need to specify '--advertise-addr eth0', without port number.