### PR TITLE
More cloud-provider generic

### DIFF
--- a/slides/kube/kubectlrun.md
+++ b/slides/kube/kubectlrun.md
@@ -245,4 +245,4 @@ at the Google NOC ...
 <br/>
 .small[are we getting 1000 packets per second]
 <br/>
-.small[of ICMP ECHO traffic from EC2 ?!?”]
+.small[of ICMP ECHO traffic from these IPs?!?”]

--- a/slides/kube/setup-k8s.md
+++ b/slides/kube/setup-k8s.md
@@ -4,7 +4,7 @@
 
 --
 
-- We used `kubeadm` on "fresh" EC2 instances with Ubuntu 16.04 LTS
+- We used `kubeadm` on freshly installed VM instances running Ubuntu 16.04 LTS
 
     1. Install Docker
 


### PR DESCRIPTION
Making the master branch more cloud-provider generic so wording doesn't need to be tweaked for different clouds. 