### PR TITLE
Clarify that these are the installed versions

### DIFF
--- a/slides/kube/versions-k8s.md
+++ b/slides/kube/versions-k8s.md
@@ -1,4 +1,4 @@
-## Brand new versions!
+## Versions installed
 
 - Kubernetes 1.9.3
 - Docker Engine 18.02.0-ce


### PR DESCRIPTION
* "Brand new" is a moving target

This is an opinion, and it's fine if you don't want it this way in the master branch - but I think calling anything that's not auto-updated "brand new" puts us at risk for that being inaccurate (and increasingly so over time).