### PR TITLE
Naming things is hard; considering scope here

### DIFF
--- a/slides/kube-halfday.yml
+++ b/slides/kube-halfday.yml
@@ -1,9 +1,11 @@
 title: |
   Deploying and Scaling Microservices
-  with Docker and Kubernetes
+  with Kubernetes
 
-chat: "[Slack](https://dockercommunity.slack.com/messages/C7GKACWDV)"
+
+#chat: "[Slack](https://dockercommunity.slack.com/messages/C7GKACWDV)"
 #chat: "[Gitter](https://gitter.im/jpetazzo/workshop-yyyymmdd-city)"
+chat: "In person!"
 
 exclude:
 - self-paced


### PR DESCRIPTION
I want to make sure people don't assume they will learn much Docker in the k8s half-day. I also want to make sure that there isn't a default link to a chat that might not get set up.