### PR TITLE
Two small fixes

### DIFF
--- a/slides/intro/Dockerfile_Tips.md
+++ b/slides/intro/Dockerfile_Tips.md
@@ -95,6 +95,6 @@ RUN <build code>
 CMD, EXPOSE ...
 ```
 
-* The build fails as soon as an instructions fails
+* The build fails as soon as an instruction fails
 * If `RUN <unit tests>` fails, the build doesn't produce an image
 * If it succeeds, it produces a clean image (without test libraries and data)

--- a/slides/intro/Dockerfile_Tips.md
+++ b/slides/intro/Dockerfile_Tips.md
@@ -90,7 +90,7 @@ COPY <test data sets and fixtures>
 RUN <unit tests>
 FROM <baseimage>
 RUN <install dependencies>
-COPY <vcode>
+COPY <code>
 RUN <build code>
 CMD, EXPOSE ...
 ```


### PR DESCRIPTION
"An" means one. So "an instruction" rather than "an instructions".  (Small grammar fix.)