### PR TITLE
Attribute authorship

### DIFF
--- a/slides/intro/intro.md
+++ b/slides/intro/intro.md
@@ -1,6 +1,6 @@
 ## A brief introduction
 
-- This was initially written to support in-person,
+- This was initially written by [Jérôme Petazzoni](https://twitter.com/jpetazzo) to support in-person,
   instructor-led workshops and tutorials
 
 - You can also follow along on your own, at your own pace

--- a/slides/kube/intro.md
+++ b/slides/kube/intro.md
@@ -1,6 +1,6 @@
 ## A brief introduction
 
-- This was initially written to support in-person,
+- This was initially written by [Jérôme Petazzoni](https://twitter.com/jpetazzo) to support in-person,
   instructor-led workshops and tutorials
 
 - You can also follow along on your own, at your own pace

--- a/slides/swarm/intro.md
+++ b/slides/swarm/intro.md
@@ -1,6 +1,6 @@
 ## A brief introduction
 
-- This was initially written to support in-person,
+- This was initially written by [Jérôme Petazzoni](https://twitter.com/jpetazzo) to support in-person,
   instructor-led workshops and tutorials
 
 - You can also follow along on your own, at your own pace


### PR DESCRIPTION
Attributing authorship here is useful so workshop participants understand why they see @jpetazzo's github referenced, even when he's not present.