### PR TITLE
Makes more sense for "in person" chat

### DIFF
--- a/slides/common/prereqs.md
+++ b/slides/common/prereqs.md
@@ -70,7 +70,7 @@ Misattributed to Benjamin Franklin
 
 - Go to [container.training](http://container.training/) to view these slides
 
-- Join the chat room on @@CHAT@@
+- Join the chat room: @@CHAT@@
 
 <!-- ```open http://container.training/``` -->
 


### PR DESCRIPTION
Since the default is no chatroom (in case one isn't configured), it makes sense to have this look reasonable whether there is a chat link or not. "Join the chat room on In person!" looks strange.