### PR TITLE
Tag images properly

### DIFF
--- a/slides/kube/ourapponkube.md
+++ b/slides/kube/ourapponkube.md
@@ -185,6 +185,7 @@ The curl command should now output:
 - Build and push the images:
   ```bash
   export REGISTRY
+  export TAG=v0.1
   docker-compose -f dockercoins.yml build
   docker-compose -f dockercoins.yml push
   ```
@@ -220,6 +221,30 @@ services:
 
 ---
 
+class: extra-details
+
+## Avoiding the `latest` tag
+
+.warning[Make sure that you've set the `TAG` variable properly!]
+
+- If you don't, the tag will default to `latest`
+
+- The problem with `latest`: nobody knows what it points to!
+
+  - the latest commit in the repo?
+
+  - the latest commit in some branch? (Which one?)
+
+  - the latest tag?
+
+  - some random version pushed by a random team member?
+
+- If you keep pushing the `latest` tag, how do you roll back?
+
+- Image tags should be meaningful, i.e. correspond to code branches, tags, or hashes
+
+---
+
 ## Deploying all the things
 
 - We can now deploy our code (as well as a redis instance)
@@ -234,7 +259,7 @@ services:
 - Deploy everything else:
   ```bash
     for SERVICE in hasher rng webui worker; do
-      kubectl run $SERVICE --image=$REGISTRY/$SERVICE
+      kubectl run $SERVICE --image=$REGISTRY/$SERVICE:$TAG
     done
   ```
 
@@ -268,7 +293,7 @@ services:
 
 ---
 
-# Exposing services internally 
+# Exposing services internally
 
 - Three deployments need to be reachable by others: `hasher`, `redis`, `rng`
 

--- a/slides/kube/rollout.md
+++ b/slides/kube/rollout.md
@@ -149,7 +149,7 @@ Our rollout is stuck. However, the app is not dead (just 10% slower).
 
 - We want to:
 
-  - revert to `v0.1` (which we now realize we didn't tag - yikes!)
+  - revert to `v0.1`
   - be conservative on availability (always have desired number of available workers)
   - be aggressive on rollout speed (update more than one pod at a time) 
   - give some time to our workers to "warm up" before starting more
@@ -163,7 +163,7 @@ spec:
     spec:
       containers:
       - name: worker
-        image: $REGISTRY/worker:latest
+        image: $REGISTRY/worker:v0.1
   strategy:
     rollingUpdate:
       maxUnavailable: 0
@@ -192,7 +192,7 @@ spec:
         spec:
           containers:
           - name: worker
-            image: $REGISTRY/worker:latest
+            image: $REGISTRY/worker:v0.1
       strategy:
         rollingUpdate:
           maxUnavailable: 0


### PR DESCRIPTION
This tags the first build with v0.1, allowing for a smoother, more
logical rollback. Also adds a slide explaining why to stay away
from latest. @kelseyhightower would be proud :-)