### PR TITLE
Increasing timeout for slow mirrors

### DIFF
--- a/prepare-vms/lib/commands.sh
+++ b/prepare-vms/lib/commands.sh
@@ -132,7 +132,7 @@ _cmd_kube() {
     sudo apt-key add - &&
     echo deb http://apt.kubernetes.io/ kubernetes-xenial main |
     sudo tee /etc/apt/sources.list.d/kubernetes.list"
-    pssh "
+    pssh --timeout 200 "
     sudo apt-get update -q &&
     sudo apt-get install -qy kubelet kubeadm kubectl
     kubectl completion bash | sudo tee /etc/bash_completion.d/kubectl"


### PR DESCRIPTION
It's possible to see this:
```
[13] 21:24:36 [SUCCESS] xx.xxx.161.183
[14] 21:24:38 [SUCCESS] xx.xxx.162.167
[15] 21:24:40 [SUCCESS] xx.xxx.166.170
[16] 21:24:40 [FAILURE] xx.xxx.167.31 Timed out, Killed by signal 9
[17] 21:24:40 [FAILURE] xx.xxx.167.37 Timed out, Killed by signal 9
[18] 21:24:40 [FAILURE] xx.xxx.166.147 Timed out, Killed by signal 9
```

Giving the package installations a little more time seems to alleviate it.
