### PR TITLE
Correcting Slack name

### DIFF
--- a/slides/kube-halfday.yml
+++ b/slides/kube-halfday.yml
@@ -2,7 +2,7 @@ title: |
   Kubernetes 101
 
 
-chat: "[SREcon slack #k8s101](https://usenix-srecon.slack.com/messages/C9XR4F5NJ/) ([get invitation](http://sreconinvite.herokuapp.com/))"
+chat: "[SREcon slack #k8s_101](https://usenix-srecon.slack.com/messages/C9XR4F5NJ/) ([get invitation](http://sreconinvite.herokuapp.com/))"
 #chat: "[Gitter](https://gitter.im/jpetazzo/workshop-yyyymmdd-city)"
 #chat: "In person!"
 


### PR DESCRIPTION
The channel has an underscore in the name.