### PR TITLE
Moving links before thanks

### DIFF
--- a/slides/kube-fullday.yml
+++ b/slides/kube-fullday.yml
@@ -38,5 +38,5 @@ chapters:
   #- kube/helm.md
   #- kube/namespaces.md
   - kube/whatsnext.md
-  - common/thankyou.md
   - kube/links.md
+  - common/thankyou.md

--- a/slides/kube-selfpaced.yml
+++ b/slides/kube-selfpaced.yml
@@ -37,5 +37,5 @@ chapters:
   - kube/helm.md
   - kube/namespaces.md
   - kube/whatsnext.md
-  - common/thankyou.md
   - kube/links.md
+  - common/thankyou.md


### PR DESCRIPTION
I've noticed that in practice, it's super weird to have a "thanks/we're done/goodbye" slide before a bunch of stuff I want to talk about. If you agree, let's move the "thanks" to the actual end.