### PR TITLE
goo.gl deprecation

### DIFF
--- a/slides/kube/kubectlrun.md
+++ b/slides/kube/kubectlrun.md
@@ -20,9 +20,9 @@
 
 .exercise[
 
-- Let's ping `google.com`:
+- Let's ping `1.1.1.1`:
   ```bash
-  kubectl run pingpong --image alpine ping google.com
+  kubectl run pingpong --image alpine ping 1.1.1.1
   ```
 
 ]
@@ -234,13 +234,11 @@ Unfortunately, `--follow` cannot (yet) be used to stream the logs from multiple 
 
 class: title
 
-Meanwhile,
-<br/>
-at the Google NOC ...
+Meanwhile, at Cloudflare...
 <br/>
 <br/>
-.small[“Why the hell]
+.small["NOC, NOC." "Who's there?"]
 <br/>
-.small[are we getting 1000 packets per second]
+.small["1000 packets per second of ICMP ECHO traffic from this workshop!"]
 <br/>
-.small[of ICMP ECHO traffic from these IPs?!?”]
+.small["It's okay! [Disappears in the background!](https://blog.cloudflare.com/dns-resolver-1-1-1-1/)"]

--- a/slides/kube/kubectlrun.md
+++ b/slides/kube/kubectlrun.md
@@ -20,9 +20,9 @@
 
 .exercise[
 
-- Let's ping `goo.gl`:
+- Let's ping `google.com`:
   ```bash
-  kubectl run pingpong --image alpine ping goo.gl
+  kubectl run pingpong --image alpine ping google.com
   ```
 
 ]


### PR DESCRIPTION
According to  https://9to5google.com/2018/03/30/google-url-shortener-shut-down/ -

"Starting on April 13, 2018, new and anonymous users will no longer be able to reach the goo.gl console to create short links. However, existing users will have access to all features like creation, management, and analytics until March 30, 2019, when the console will be discontinued.

Google notes “all links will continue to redirect to the intended destination” even after 2019, with users also able to export link information from the console."

Given that goo.gl may redirect in unknown ways very soon, we probably don't want to keep this specific ping pointing to it? (The existing shortened URLs will keep working indefinitely.)