### PR TITLE
kubectl get all missing-type workaround

### DIFF
--- a/slides/kube/kubectlrun.md
+++ b/slides/kube/kubectlrun.md
@@ -53,7 +53,7 @@ We should see the following things:
 - `rs/pingpong-xxxx` (a *replica set* created by the deployment)
 - `po/pingpong-yyyy` (a *pod* created by the replica set)
 
-Note: as of 1.10, types aren't displayed! [This may be a bug.](https://github.com/kubernetes/kubernetes/issues/62340)
+Note: as of 1.10.0, types aren't displayed! [This is a bug and will be corrected in 1.10.1.](https://github.com/kubernetes/kubernetes/issues/62340)
 
 ---
 


### PR DESCRIPTION
In 1.10, `kubectl get all` stopped printing resource types. Since we use these in the workshop, I'm making this modification to clarify how people can distinguish the types now that they aren't displayed with `deploy/`, `rs/`, and `po/`.

Bug report here: https://github.com/kubernetes/kubernetes/issues/62340