### PR TITLE
Clarify error message upon start & endpoints

### DIFF
--- a/slides/kube/kubectlexpose.md
+++ b/slides/kube/kubectlexpose.md
@@ -224,7 +224,7 @@ class: extra-details
   kubectl get endpoints elastic -o yaml
   ```
 
-- These addresses will show us a list of IP addresses
+- These commands will show us a list of IP addresses
 
 - These IP addresses should match the addresses of the corresponding pods:
   ```bash

--- a/slides/kube/kubectlexpose.md
+++ b/slides/kube/kubectlexpose.md
@@ -137,8 +137,9 @@ Note: please DO NOT call the service `search`. It would collide with the TLD.
 
 --
 
-We may see `curl: (7) Failed to connect to _IP_ port 9200: Connection refused`
-This is normal while the service starts up
+We may see `curl: (7) Failed to connect to _IP_ port 9200: Connection refused`.
+
+This is normal while the service starts up.
 
 --
 

--- a/slides/kube/kubectlexpose.md
+++ b/slides/kube/kubectlexpose.md
@@ -213,12 +213,15 @@ class: extra-details
 
 ## Viewing endpoint details
 
-- When we have many endpoints, the previous command truncates the list
+- When we have many endpoints, our display commands truncate the list
+  ```bash
+  kubectl get endpoints
+  ```
 
 - If we want to see the full list, we can use one of the following commands:
   ```bash
-  kubectl describe endpoint elastic
-  kubectl get endpoint elastic -o yaml
+  kubectl describe endpoints elastic
+  kubectl get endpoints elastic -o yaml
   ```
 
 - These addresses will show us a list of IP addresses
@@ -227,3 +230,23 @@ class: extra-details
   ```bash
   kubectl get pods -l run=elastic -o wide
   ```
+
+---
+
+class: extra-details
+
+## endpoints not endpoint
+
+- `endpoints` is the only resource that cannot be singular
+
+```bash
+kubectl get endpoint
+kubectl describe endpoint
+```
+
+--
+
+.warning[error: the server doesn't have a resource type "endpoint"]
+
+- This is because the type itself is plural (unlike every other resource)
+- There is no `endpoint` object: `type Endpoints struct`

--- a/slides/kube/kubectlexpose.md
+++ b/slides/kube/kubectlexpose.md
@@ -235,18 +235,17 @@ class: extra-details
 
 class: extra-details
 
-## endpoints not endpoint
+## `endpoints` not `endpoint`
 
 - `endpoints` is the only resource that cannot be singular
 
 ```bash
-kubectl get endpoint
-kubectl describe endpoint
+$ kubectl get endpoint
+error: the server doesn't have a resource type "endpoint"
 ```
 
---
-
-.warning[error: the server doesn't have a resource type "endpoint"]
-
 - This is because the type itself is plural (unlike every other resource)
+
 - There is no `endpoint` object: `type Endpoints struct`
+
+- The type doesn't represent a single endpoint, but a list of endpoints

--- a/slides/kube/kubectlexpose.md
+++ b/slides/kube/kubectlexpose.md
@@ -137,7 +137,12 @@ Note: please DO NOT call the service `search`. It would collide with the TLD.
 
 --
 
-Our requests are load balanced across multiple pods.
+We may see `curl: (7) Failed to connect to _IP_ port 9200: Connection refused`
+This is normal while the service starts up
+
+--
+
+Once it's running, our requests are load balanced across multiple pods.
 
 ---
 


### PR DESCRIPTION
If we're impatient (and let's be real; I'm always impatient!), we can find ourselves querying the elastic service before it's finished starting up, and in that case, we'll see an entirely expected error. We should warn students so they aren't surprised.

Also, we can't have singular `endpoint`, only plural `endpoints`. That's worth noting.