### PR TITLE
removing extra leading spaces which break everything

### DIFF
--- a/slides/kube/namespaces.md
+++ b/slides/kube/namespaces.md
@@ -40,12 +40,12 @@
 
 - We can create namespaces with a very minimal YAML, e.g.:
   ```bash
-	  kubectl apply -f- <<EOF
-	  apiVersion: v1
-	  kind: Namespace
-	  metadata:
-	    name: blue
-	  EOF
+	kubectl apply -f- <<EOF
+	apiVersion: v1
+	kind: Namespace
+	metadata:
+	  name: blue
+	EOF
   ```
 
 - If we are using a tool like Helm, it will create namespaces automatically


### PR DESCRIPTION
Annoyingly enough, the two extra leading spaces prevent this from working if it's copy-pasted. Check it out in action:

```
[13.92.59.234] (local) docker@node1 ~
$   kubectl apply -f- <<EOF
>   apiVersion: v1
>   kind: Namespace
>   metadata:
>     name: blue
>   EOF
> ^C
[13.92.59.234] (local) docker@node1 ~
$ kubectl apply -f- <<EOF
> apiVersion: v1
> kind: Namespace
> metadata:
>   name: blue
> EOF
namespace "blue" created
[13.92.59.234] (local) docker@node1 ~
$ 
```