### PR TITLE
Patch only daemonset pods

### DIFF
--- a/slides/kube/daemonset.md
+++ b/slides/kube/daemonset.md
@@ -457,6 +457,6 @@ The timestamps should give us a hint about how many pods are currently receiving
       labels:
         isactive: "yes"
     '
-    kubectl get pods -l run=rng -o name |
+    kubectl get pods -l run=rng -l controller-revision-hash -o name |
       xargs kubectl patch -p "$PATCH" 
   ```


### PR DESCRIPTION
When I tested this, I discovered that oops, we're actually patching both the daemonset and the deployment! I looked around for a plausible difference we could use to differentiate, and found one, but perhaps we want to do this a different way. We definitely have an error as it stands currently.

Evidence that without this extra flag, the deployment also gets patched:
```
[52.186.28.163] (local) docker@node1 ~/container.training/stacks
$ kubectl get pods -l run=rng -o name -l controller-revision-hash |
>   xargs kubectl patch -p "$PATCH"
pod "rng-4xwr9" patched
pod "rng-lhl7j" patched
[52.186.28.163] (local) docker@node1 ~/container.training/stacks
$ kubectl get pods -l run=rng -o name  |   xargs kubectl patch -p "$PATCH"
pod "rng-4xwr9" not patched
pod "rng-76b886bb88-pfqbd" patched
pod "rng-lhl7j" not patched
exit
exit
[52.186.28.163] (local) docker@node1 ~/container.training/stacks
$ 
```