### PR TITLE
Clarify an off-by-one amount of pods

### DIFF
--- a/slides/kube/daemonset.md
+++ b/slides/kube/daemonset.md
@@ -202,7 +202,7 @@ And one too many pods...
 
   - *one pod per node* for the daemonset
 
-.footnote[(We don't run these pods on master nodes, so it's *one pod per worker node*.)]
+.footnote[(Off by one? We don't run these pods on the node hosting the control plane.)]
 
 ---
 

--- a/slides/kube/daemonset.md
+++ b/slides/kube/daemonset.md
@@ -202,6 +202,8 @@ And one too many pods...
 
   - *one pod per node* for the daemonset
 
+.footnote[(We don't run these pods on master nodes, so it's *one pod per worker node*.)]
+
 ---
 
 ## What are all these pods doing?


### PR DESCRIPTION
Sometimes things run on _every_ node, and sometimes they don't run on the master node. Since we're calling out the number of pods, we probably don't want people to be confused here. There is one pod too many, even though the number of pods matches the number of (workers plus master).