### PR TITLE
Rearrange kube halfday

### DIFF
--- a/slides/kube-halfday.yml
+++ b/slides/kube-halfday.yml
@@ -36,7 +36,7 @@ chapters:
   - kube/daemonset.md
   - kube/rollout.md
 - - kube/logs-cli.md
-# Bridget hasn't added ELK yet
+# Bridget hasn't added EFK yet
   #- kube/logs-centralized.md
   - kube/helm.md
   - kube/namespaces.md

--- a/slides/kube-halfday.yml
+++ b/slides/kube-halfday.yml
@@ -2,21 +2,24 @@ title: |
   Kubernetes 101
 
 #chat: "[Slack](https://dockercommunity.slack.com/messages/C7GKACWDV)"
-chat: "[Gitter](https://gitter.im/jpetazzo/training-20180413-paris)"
-#chat: "In person!"
+#chat: "[Gitter](https://gitter.im/jpetazzo/training-20180413-paris)"
+chat: "In person!"
 
 exclude:
 - self-paced
 
 chapters:
 - common/title.md
-- logistics.md
+#- logistics.md
+# Bridget-specific; others use logistics.md
+- logistics-bridget.md
 - kube/intro.md
 - common/about-slides.md
 - common/toc.md
 - - common/prereqs.md
   - kube/versions-k8s.md
   - common/sampleapp.md
+# Bridget doesn't go into as much depth with compose
   #- common/composescale.md
   - common/composedown.md
   - kube/concepts-k8s.md
@@ -24,18 +27,21 @@ chapters:
   - kube/declarative.md
   - kube/kubenet.md
   - kube/kubectlget.md
-- - kube/setup-k8s.md
-  - kube/kubectlrun.md
+  - kube/setup-k8s.md
+- - kube/kubectlrun.md
   - kube/kubectlexpose.md
   - kube/ourapponkube.md
-  - kube/dashboard.md
-- - kube/kubectlscale.md
+- - kube/dashboard.md
+  - kube/kubectlscale.md
   - kube/daemonset.md
   - kube/rollout.md
-  - kube/logs-cli.md
+- - kube/logs-cli.md
+# Bridget hasn't added ELK yet
   #- kube/logs-centralized.md
-  #- kube/helm.md
-  #- kube/namespaces.md
+  - kube/helm.md
+  - kube/namespaces.md
   - kube/whatsnext.md
-  - kube/links.md
+#  - kube/links.md
+# Bridget-specific
+  - kube/links-bridget.md
   - common/thankyou.md


### PR DESCRIPTION
Since comments are okay, I'd just as soon keep the half-day template set up with the defaults I'm the most likely to use (for the logistics and links), with comments making it easy for people to switch back to the standard. Please let me know if that's okay. I'm trying to avoid keeping a "me" specific kube halfday file - I want it to be as usable for any instructor as feasible, while still having less me-specific configuration that I'll need to do every time.

I also changed the chapter breaks to match what you did in Paris, as I think the flow looked a bit better. I'll try using that this week.

Since I've consistently run a little short, I'm going to try adding some (but not all) of the new content to the default deliverable.

I'm also going to keep "in person" as the chat default.

Input welcome!