### PR TITLE
Re-ordering "kubectl apply" discussion

### DIFF
--- a/slides/kube/dashboard.md
+++ b/slides/kube/dashboard.md
@@ -256,9 +256,9 @@ The dashboard will then ask you which authentication you want to use.
 
 - It's safe if you use HTTPS URLs from trusted sources
 
+- Example: the official setup instructions for most pod networks
+
 --
 
 - It introduces new failure modes
-
-- Example: the official setup instructions for most pod networks
 

--- a/slides/kube/dashboard.md
+++ b/slides/kube/dashboard.md
@@ -260,5 +260,5 @@ The dashboard will then ask you which authentication you want to use.
 
 --
 
-- It introduces new failure modes
+- It introduces new failure modes (like if you try to apply yaml from a link that's no longer valid)
 


### PR DESCRIPTION
It's tricky to see the difference from the diff; here's the original:

<img width="817" alt="screen shot 2018-04-22 at 12 15 14 pm" src="https://user-images.githubusercontent.com/2104453/39097802-374ebd74-4627-11e8-8cfe-0067c8fc426e.png">

The problem here is it sounds like we're saying that an example of a new failure mode is the official setup instructions for pod networks.

I think what we want to say is that kubectl apply can introduce new failure modes (and maybe we want to detail a few?)

<img width="845" alt="screen shot 2018-04-22 at 12 15 23 pm" src="https://user-images.githubusercontent.com/2104453/39097795-1e740d68-4627-11e8-85c0-48d2e82e5360.png">