### PR TITLE
Correction for helm completion

### DIFF
--- a/slides/kube/helm.md
+++ b/slides/kube/helm.md
@@ -50,7 +50,7 @@
 
 - Add the `helm` completion:
   ```bash
-  . <(helm completion $SHELL)
+  . <(helm completion $(basename $SHELL))
   ```
 
 ]


### PR DESCRIPTION
I ran into an issue with this as published. If you agree, perhaps this would work better?

```
[40.121.176.114] (local) docker@node1 ~/container.training/stacks
$ . <(helm completion $SHELL)
Error: unsupported shell type "/bin/bash"
[40.121.176.114] (local) docker@node1 ~/container.training/stacks
$ . <(helm completion $(basename $SHELL))
[40.121.176.114] (local) docker@node1 ~/container.training/stacks
$ 
```