### PR TITLE
move visualizer to service and stack

### DIFF
--- a/slides/swarm/compose2swarm.md
+++ b/slides/swarm/compose2swarm.md
@@ -112,9 +112,10 @@ services:
 
 .exercise[
 
-- Deploy our local registry:
+- Deploy our local registry and the visualizer:
   ```bash
-  docker stack deploy registry --compose-file registry.yml
+  docker stack deploy --compose-file registry.yml registry
+  docker stack deploy -c visualizer.yml viz
   ```
 
 ]

--- a/slides/swarm/compose2swarm.md
+++ b/slides/swarm/compose2swarm.md
@@ -112,10 +112,9 @@ services:
 
 .exercise[
 
-- Deploy our local registry and the visualizer:
+- Deploy our local registry:
   ```bash
   docker stack deploy --compose-file registry.yml registry
-  docker stack deploy -c visualizer.yml viz
   ```
 
 ]

--- a/slides/swarm/firstservice.md
+++ b/slides/swarm/firstservice.md
@@ -426,16 +426,14 @@ class: extra-details
 
 .exercise[
 
-- Get the source code of this simple-yet-beautiful visualization app:
+- Create a service of this simple-yet-beautiful visualization app:
   ```bash
-  cd ~
-  git clone git://github.com/dockersamples/docker-swarm-visualizer
-  ```
-
-- Build and run the Swarm visualizer:
-  ```bash
-  cd docker-swarm-visualizer
-  docker-compose up -d
+  docker service create \
+  --name=viz \
+  --publish=8080:8080/tcp \
+  --constraint=node.role==manager \
+  --mount=type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
+  dockersamples/visualizer
   ```
 
   <!-- ```longwait Creating dockerswarmvisualizer_viz_1``` -->
@@ -450,7 +448,7 @@ class: extra-details
 
 .exercise[
 
-- Point your browser to port 8080 of your node1's public ip
+- Point your browser to port 8080 of a nodes public ip
 
   (If you use Play-With-Docker, click on the (8080) badge)
 
@@ -476,19 +474,17 @@ class: extra-details
 
 - Instead of viewing your cluster, this could take care of logging, metrics, autoscaling ...
 
-- We can run it within a service, too! We won't do it, but the command would look like:
+- Ideally all things in a Swarm run in Services (cattle not pets)
 
-  ```bash
-    docker service create \
-      --mount source=/var/run/docker.sock,type=bind,target=/var/run/docker.sock \
-      --name viz --constraint node.role==manager ...
-  ```
+.footnote[
 
 Credits: the visualization code was written by
 [Francisco Miranda](https://github.com/maroshii).
-<br/>
+
 [Mano Marks](https://twitter.com/manomarks) adapted
 it to Swarm and maintains it.
+
+]
 
 ---
 

--- a/slides/swarm/firstservice.md
+++ b/slides/swarm/firstservice.md
@@ -426,14 +426,10 @@ class: extra-details
 
 .exercise[
 
-- Create a service of this simple-yet-beautiful visualization app:
+- Run this simple-yet-beautiful visualization app:
   ```bash
-  docker service create \
-  --name=viz \
-  --publish=8080:8080/tcp \
-  --constraint=node.role==manager \
-  --mount=type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
-  dockersamples/visualizer
+  cd ~/container.training/stacks
+  docker-compose -f visualizer.yml up -d
   ```
 
   <!-- ```longwait Creating dockerswarmvisualizer_viz_1``` -->
@@ -448,7 +444,7 @@ class: extra-details
 
 .exercise[
 
-- Point your browser to port 8080 of a nodes public ip
+- Point your browser to port 8080 of your node1's public ip
 
   (If you use Play-With-Docker, click on the (8080) badge)
 
@@ -474,7 +470,13 @@ class: extra-details
 
 - Instead of viewing your cluster, this could take care of logging, metrics, autoscaling ...
 
-- Ideally all things in a Swarm run in Services (cattle not pets)
+- We can run it within a service, too! We won't do it yet, but the command would look like:
+
+  ```bash
+    docker service create \	
+      --mount source=/var/run/docker.sock,type=bind,target=/var/run/docker.sock \	
+      --name viz --constraint node.role==manager ...	
+  ```
 
 .footnote[
 

--- a/slides/swarm/firstservice.md
+++ b/slides/swarm/firstservice.md
@@ -473,9 +473,9 @@ class: extra-details
 - We can run it within a service, too! We won't do it yet, but the command would look like:
 
   ```bash
-    docker service create \	
-      --mount source=/var/run/docker.sock,type=bind,target=/var/run/docker.sock \	
-      --name viz --constraint node.role==manager ...	
+    docker service create \
+      --mount source=/var/run/docker.sock,type=bind,target=/var/run/docker.sock \
+      --name viz --constraint node.role==manager ...
   ```
 
 .footnote[

--- a/stacks/visualizer.yml
+++ b/stacks/visualizer.yml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+  viz:
+    image: dockersamples/visualizer
+    volumes:
+    - "/var/run/docker.sock:/var/run/docker.sock"
+    ports:
+    - "8080:8080"
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager


### PR DESCRIPTION
Removing the `git clone` and `docker-compose up` of the visualizer since we introduce it after services, so no reason to spend time building it on node1.  I felt this was faster, and more "swarmy" then compose, but it does end up showing container in viz UI, but I think that's fine.

Minor edit: changed format of stack deploy command to put name at end, per the proper format order. I'll make another PR later to change the rest of them to match the official command format:

`Usage:	docker stack deploy [OPTIONS] STACK`