### PR TITLE
reordering stack deploy cmd format

### DIFF
--- a/slides/swarm/compose2swarm.md
+++ b/slides/swarm/compose2swarm.md
@@ -114,7 +114,7 @@ services:
 
 - Deploy our local registry:
   ```bash
-  docker stack deploy registry --compose-file registry.yml
+  docker stack deploy --compose-file registry.yml registry
   ```
 
 ]
@@ -304,7 +304,7 @@ services:
 
 - Create the application stack:
   ```bash
-  docker stack deploy dockercoins --compose-file dockercoins.yml
+  docker stack deploy --compose-file dockercoins.yml dockercoins
   ```
 
 ]

--- a/slides/swarm/healthchecks.md
+++ b/slides/swarm/healthchecks.md
@@ -120,7 +120,7 @@ We will use the following Compose file (`stacks/dockercoins+healthcheck.yml`):
 
 - Deploy the updated stack:
   ```bash
-  docker stack deploy dockercoins --compose-file dockercoins+healthcheck.yml
+  docker stack deploy --compose-file dockercoins+healthcheck.yml dockercoins 
   ```
 
 ]

--- a/slides/swarm/logging.md
+++ b/slides/swarm/logging.md
@@ -187,7 +187,7 @@ class: elk-auto
   ```bash
   docker-compose -f elk.yml build
   docker-compose -f elk.yml push
-  docker stack deploy elk -c elk.yml
+  docker stack deploy -c elk.yml elk
   ```
 
 ]


### PR DESCRIPTION
Makes `docker stack deploy` commands consistent in their format to match docs:

`Usage:	docker stack deploy [OPTIONS] STACK`