### PR TITLE
adding more images to cache

### DIFF
--- a/prepare-vms/lib/commands.sh
+++ b/prepare-vms/lib/commands.sh
@@ -399,6 +399,7 @@ pull_tag() {
 	    alpine \
 	    registry \
 	    nicolaka/netshoot \
+	    jpetazzo/trainingwheels \
 	    golang \
             training/namer \
 	    dockercoins/hasher \

--- a/prepare-vms/lib/commands.sh
+++ b/prepare-vms/lib/commands.sh
@@ -393,9 +393,22 @@ pull_tag() {
             ubuntu:latest \
             fedora:latest \
             centos:latest \
+	    elasticsearch:2 \
             postgres \
             redis \
+	    alpine \
+	    registry \
+	    nicolaka/netshoot \
+	    golang \
             training/namer \
+	    dockercoins/hasher \
+	    dockercoins/rng \
+	    dockercoins/webui \
+	    dockercoins/worker \
+	    logstash \
+	    prom/node-exporter \
+	    google/cadvisor \
+	    dockersamples/visualizer \
             nathanleclaire/redisonrails; do
         sudo -u docker docker pull $I
     done'


### PR DESCRIPTION
Based on most images used in swarm and fundamentals workshops.

@bridgetkromhout do you use this command in your vm setup? If so are your images in this list?

`./workshopctl pull_images <tag>`

Future thought... make this pull based on workshop type: fundamentals/kubernetes/swarm.