### PR TITLE
moving to 3 node swarms by default

### DIFF
--- a/slides/swarm/firstservice.md
+++ b/slides/swarm/firstservice.md
@@ -96,7 +96,7 @@ class: extra-details
 
 - Scale the service to ensure 2 copies per node:
   ```bash
-  docker service update pingpong --replicas 10
+  docker service update pingpong --replicas 6
   ```
 
 - Check that we have two containers on the current node:
@@ -168,12 +168,12 @@ class: extra-details
 
 - Scale the service to ensure 3 copies per node:
   ```bash
-  docker service update pingpong --replicas 15 --detach=false
+  docker service update pingpong --replicas 9 --detach=false
   ```
 
 - And then to 4 copies per node:
   ```bash
-  docker service update pingpong --replicas 20 --detach=true
+  docker service update pingpong --replicas 12 --detach=true
   ```
 
 ]
@@ -207,7 +207,7 @@ class: extra-details
 
 - Create an ElasticSearch service (and give it a name while we're at it):
   ```bash
-  docker service create --name search --publish 9200:9200 --replicas 7 \
+  docker service create --name search --publish 9200:9200 --replicas 5 \
          elasticsearch`:2`
   ```
 
@@ -294,7 +294,7 @@ apk add --no-cache jq
 Traffic is handled by our clusters [TCP routing mesh](
 https://docs.docker.com/engine/swarm/ingress/).
 
-Each request is served by one of the 7 instances, in rotation.
+Each request is served by one of the instances, in rotation.
 
 Note: if you try to access the service from your browser,
 you will probably see the same

--- a/slides/swarm/metrics.md
+++ b/slides/swarm/metrics.md
@@ -1183,7 +1183,7 @@ class: prom
 
 ]
 
-You should see 11 endpoints (5 cadvisor, 5 node, 1 prometheus).
+You should see 7 endpoints (3 cadvisor, 3 node, 1 prometheus).
 
 Their state should be "UP".
 

--- a/slides/swarm/morenodes.md
+++ b/slides/swarm/morenodes.md
@@ -35,33 +35,7 @@ class: in-person
 
 ## Building our full cluster
 
-- We could SSH to nodes 3, 4, 5; and copy-paste the command
-
---
-
-class: in-person
-
-- Or we could use the AWESOME POWER OF THE SHELL!
-
---
-
-class: in-person
-
-![Mario Red Shell](images/mario-red-shell.png)
-
---
-
-class: in-person
-
-- No, not *that* shell
-
----
-
-class: in-person
-
-## Let's form like Swarm-tron
-
-- Let's get the token, and loop over the remaining nodes with SSH
+- Let's get the token, and use a one-liner for the remaining node with SSH
 
 .exercise[
 
@@ -70,11 +44,9 @@ class: in-person
   TOKEN=$(docker swarm join-token -q manager)
   ```
 
-- Loop over the 3 remaining nodes:
+- Add the remaining node:
   ```bash
-    for NODE in node3 node4 node5; do
-      ssh $NODE docker swarm join --token $TOKEN node1:2377
-    done
+    ssh node3 docker swarm join --token $TOKEN node1:2377
   ```
 
 ]


### PR DESCRIPTION
As cool as 5 nodes are, it's harder to get funding and 3 nodes get us the same experience. To match the kube 3-node workshop, I'd like to move the swarm workshop to 3 nodes by default.