### PR TITLE
Use busybox for telnet instead of alpine and fix image links

### DIFF
--- a/slides/intro/Advanced_Dockerfiles.md
+++ b/slides/intro/Advanced_Dockerfiles.md
@@ -1,6 +1,6 @@
 # Advanced Dockerfiles
 
-![construction](images/title-advanced-dockerfiles.jpg)
+![construction](../images/title-advanced-dockerfiles.jpg)
 
 ---
 

--- a/slides/intro/Compose_For_Dev_Stacks.md
+++ b/slides/intro/Compose_For_Dev_Stacks.md
@@ -99,7 +99,7 @@ including linking the relevant containers together.
 
 Verify that the app is running at `http://<yourHostIP>:8000`.
 
-![composeapp](images/composeapp.png)
+![composeapp](../images/composeapp.png)
 
 ---
 

--- a/slides/intro/Compose_For_Dev_Stacks.md
+++ b/slides/intro/Compose_For_Dev_Stacks.md
@@ -51,7 +51,7 @@ Before diving in, let's see a small example of Compose in action.
 
 ## Compose in action
 
-![composeup](images/composeup.gif)
+![composeup](../images/composeup.gif)
 
 ---
 

--- a/slides/intro/Working_With_Volumes.md
+++ b/slides/intro/Working_With_Volumes.md
@@ -259,7 +259,7 @@ $ docker run -d --name redis28 redis:2.8
 Connect to the Redis container and set some data.
 
 ```bash
-$ docker run -ti --link redis28:redis alpine telnet redis 6379
+$ docker run -ti --link redis28:redis busybox telnet redis 6379
 ```
 
 Issue the following commands:
@@ -298,7 +298,7 @@ class: extra-details
 Connect to the Redis container and see our data.
 
 ```bash
-docker run -ti --link redis30:redis alpine telnet redis 6379
+docker run -ti --link redis30:redis busybox telnet redis 6379
 ```
 
 Issue a few commands.


### PR DESCRIPTION
Newer versions of alpine may not include telnet by default, may be useful to use busybox instead
