### PR TITLE
fix docker-compose scale up change

### DIFF
--- a/slides/common/composescale.md
+++ b/slides/common/composescale.md
@@ -106,7 +106,7 @@ We have available resources.
 
 - Start one more `worker` container:
   ```bash
-  docker-compose up --scale worker=2
+  docker-compose up -d --scale worker=2
   ```
 
 - Look at the performance graph (it should show a x2 improvement)
@@ -127,7 +127,7 @@ We have available resources.
 
 - Start eight more `worker` containers:
   ```bash
-  docker-compose up --scale worker=10
+  docker-compose up -d --scale worker=10
   ```
 
 - Look at the performance graph: does it show a x10 improvement?


### PR DESCRIPTION
I changed the scale command in docker-compose and need to fix its syntax. It needs `-d` to ensure the command stays detached.