### PR TITLE
Show how to access internal services with kubectl proxy

### DIFF
--- a/slides/kube-fullday.yml
+++ b/slides/kube-fullday.yml
@@ -33,6 +33,7 @@ chapters:
   - kube/kubectlrun.md
 - - kube/kubectlexpose.md
   - kube/ourapponkube.md
+  - kube/kubectlproxy.md
   - kube/dashboard.md
 - - kube/kubectlscale.md
   - kube/daemonset.md

--- a/slides/kube-halfday.yml
+++ b/slides/kube-halfday.yml
@@ -35,6 +35,7 @@ chapters:
 - - kube/kubectlrun.md
   - kube/kubectlexpose.md
   - kube/ourapponkube.md
+  #- kube/kubectlproxy.md
 - - kube/dashboard.md
   - kube/kubectlscale.md
   - kube/daemonset.md

--- a/slides/kube-selfpaced.yml
+++ b/slides/kube-selfpaced.yml
@@ -32,6 +32,7 @@ chapters:
   - kube/kubectlrun.md
 - - kube/kubectlexpose.md
   - kube/ourapponkube.md
+  - kube/kubectlproxy.md
   - kube/dashboard.md
 - - kube/kubectlscale.md
   - kube/daemonset.md

--- a/slides/kube/kubectlproxy.md
+++ b/slides/kube/kubectlproxy.md
@@ -1,0 +1,117 @@
+# Accessing internal services with `kubectl proxy`
+
+- `kubectl proxy` runs a proxy in the foreground
+
+- This proxy lets us access the Kubernetes API without authentication
+
+  (`kubectl proxy` adds our credentials on the fly to the requests)
+
+- This proxy lets us access the Kubernetes API over plain HTTP
+
+- This is a great tool to learn and experiment with the Kubernetes API
+
+- The Kubernetes API also gives us a proxy to HTTP and HTTPS services
+
+- Therefore, we can use `kubectl proxy` to access internal services
+
+  (Without using a `NodePort` or similar service)
+
+---
+
+## Secure by default
+
+- By default, the proxy listens on port 8001
+
+  (But this can be changed, or we can tell `kubectl proxy` to pick a port)
+
+- By default, the proxy binds to `127.0.0.1`
+
+  (Making it unreachable from other machines, for security reasons)
+
+- By default, the proxy only accepts connections from:
+
+  `^localhost$,^127\.0\.0\.1$,^\[::1\]$`
+
+- This is great when running `kubectl proxy` locally
+
+- Not-so-great when running it on a remote machine
+
+---
+
+## Running `kubectl proxy` on a remote machine
+
+- We are going to bind to `INADDR_ANY` instead of `127.0.0.1`
+
+- We are going to accept connections from any address
+
+.exercise[
+
+- Run an open proxy to the Kubernetes API:
+  ```bash
+  kubectl proxy --port=8888 --address=0.0.0.0 --accept-hosts=.*
+  ```
+
+]
+
+.warning[Anyone can now do whatever they want with our Kubernetes cluster!
+<br/>
+(Don't do this on a real cluster!)]
+
+---
+
+## Viewing available API routes
+
+- The default route (i.e. `/`) shows a list of available API endpoints
+
+.exercise[
+
+- Point your browser to the IP address of the node running `kubectl proxy`, port 8888
+
+]
+
+The result should look like this:
+```json
+{
+  "paths": [
+    "/api",
+    "/api/v1",
+    "/apis",
+    "/apis/",
+    "/apis/admissionregistration.k8s.io",
+    …
+```
+
+---
+
+## Connecting to a service through the proxy
+
+- The API can proxy HTTP and HTTPS requests by accessing a special route:
+  ```
+  /api/v1/namespaces/`name_of_namespace`/services/`name_of_service`/proxy
+  ```
+
+- Since we now have access to the API, we can use this special route
+
+.exercise[
+
+- Access the `hasher` service through the special proxy route:
+  ```open
+  http://`X.X.X.X`:8888/api/v1/namespaces/default/services/hasher/proxy
+  ```
+
+]
+
+You should see the banner of the hasher service: `HASHER running on ...`
+
+---
+
+## Stopping the proxy
+
+- Remember: as it is running right now, `kubectl proxy` gives open access to our cluster
+
+.exercise[
+
+- Stop the `kubectl proxy`
+
+]
+

--- a/slides/kube/kubectlproxy.md
+++ b/slides/kube/kubectlproxy.md
@@ -111,7 +111,7 @@ You should see the banner of the hasher service: `HASHER running on ...`
 
 .exercise[
 
-- Stop the `kubectl proxy`
+- Stop the `kubectl proxy` process with Ctrl-C
 
 ]
 


### PR DESCRIPTION
I've added a section explaining `kubectl proxy` and showing how to use it to access internal services through the special `.../proxy` route.

I've added that section to the `fullday` and `selfpaced` variants of the curriculum.

Let me know if you have thoughts and opinions about that! (I'm also happy to just merge it if that content is not relevant to you at the moment and/or you can't review it!)