### PR TITLE
Closing the loop on what the proxy shows

### DIFF
--- a/slides/kube/kubectlproxy.md
+++ b/slides/kube/kubectlproxy.md
@@ -105,6 +105,27 @@ You should see the banner of the hasher service: `HASHER running on ...`
 
 ---
 
+## Compare proxy output to CLI output
+
+.exercise[
+
+- Inspect the `hasher` pod:
+  ```bash
+  kubectl describe pods -l run=hasher
+  ```
+
+]
+
+The `Name:` field should match the one shown by the proxy
+
+example: `Name:           hasher-57d84dfccf-srfft`
+
+--
+
+You can also see lots of other interesting settings, events, etc!
+
+---
+
 ## Stopping the proxy
 
 - Remember: as it is running right now, `kubectl proxy` gives open access to our cluster


### PR DESCRIPTION
I like the proxy section, but I think it's missing a punchline. When you see the endpoint, a natural reaction could be "so what", if you don't see the connection to what you've already learned. I propose adding a page right there that shows we're seeing the same thing in a different place.

<img width="1025" alt="screen shot 2018-06-04 at 8 35 43 pm" src="https://user-images.githubusercontent.com/2104453/40950200-5feb06a2-6837-11e8-8602-24d98314a00d.png">
