### PR TITLE
Clarifying rollout failure via dashboard

### DIFF
--- a/slides/kube/rollout.md
+++ b/slides/kube/rollout.md
@@ -192,6 +192,8 @@ class: extra-details
 
 ## Checking the dashboard during the bad rollout
 
+If you haven't deployed the Kubernetes dashboard earlier, just skip this slide.
+
 .exercise[
 
 - Check which port the dashboard is on:

--- a/slides/kube/rollout.md
+++ b/slides/kube/rollout.md
@@ -190,6 +190,33 @@ class: extra-details
 
 ---
 
+## Checking the dashboard during the bad rollout
+
+.exercise[
+
+- Check which port the dashboard is on:
+  ```bash
+  kubectl -n kube-system get svc socat
+  ```
+
+]
+
+Note the `3xxxx` port.
+
+.exercise[
+
+- Connect to http://oneofournodes:3xxxx/
+
+<!-- ```open https://node1:3xxxx/``` -->
+
+]
+
+--
+
+- We have failures in Deployments, Pods, and Replica Sets
+
+---
+
 ## Recovering from a bad rollout
 
 - We could push some `v0.3` image


### PR DESCRIPTION
We might want to take the opportunity to show off what failure looks like on the dashboard. The visual indicator is kinda cool.

<img width="954" alt="screen shot 2018-06-04 at 8 58 14 pm" src="https://user-images.githubusercontent.com/2104453/40951030-f61d7b7a-683a-11e8-8901-9215575c90b3.png">

<img width="1156" alt="screen shot 2018-06-04 at 8 59 51 pm" src="https://user-images.githubusercontent.com/2104453/40951034-f955d788-683a-11e8-893f-c1a584950ea7.png">

(Edits welcome, if you like this idea.)