### PR TITLE
Update Container_Networking_Basics.md

### DIFF
--- a/slides/intro/Container_Networking_Basics.md
+++ b/slides/intro/Container_Networking_Basics.md
@@ -98,7 +98,7 @@ $ curl localhost:32768
 * We can see that metadata with `docker inspect`:
 
 ```bash
-$ docker inspect nginx --format {{.Config.ExposedPorts}}
+$ docker inspect --format '{{.Config.ExposedPorts}}' nginx
 map[80/tcp:{}]
 ```
 


### PR DESCRIPTION
Added needed single quotes. I've also moved `nginx` to the end of the line, to follow a more consistent syntax  (`options` before `name|id`).

```
Usage:	docker inspect [OPTIONS] NAME|ID [NAME|ID...]

Return low-level information on Docker objects

Options:
  -f, --format string   Format the output using the given Go template
  -s, --size            Display total file sizes if the type is container
      --type string     Return JSON for specified type
```