### PR TITLE
Enforce alpine version that includes telnet

### DIFF
--- a/slides/intro/Working_With_Volumes.md
+++ b/slides/intro/Working_With_Volumes.md
@@ -259,7 +259,7 @@ $ docker run -d --name redis28 redis:2.8
 Connect to the Redis container and set some data.
 
 ```bash
-$ docker run -ti --link redis28:redis alpine telnet redis 6379
+$ docker run -ti --link redis28:redis alpine:3.6 telnet redis 6379
 ```
 
 Issue the following commands:

--- a/slides/intro/Working_With_Volumes.md
+++ b/slides/intro/Working_With_Volumes.md
@@ -298,7 +298,7 @@ class: extra-details
 Connect to the Redis container and see our data.
 
 ```bash
-docker run -ti --link redis30:redis alpine telnet redis 6379
+docker run -ti --link redis30:redis alpine:3.6 telnet redis 6379
 ```
 
 Issue a few commands.


### PR DESCRIPTION
alpine 3.7 does not include `telnet` by default https://github.com/gliderlabs/docker-alpine/issues/397#issuecomment-375415746