### PR TITLE
Make dockercoins_rng single threaded again

### DIFF
--- a/dockercoins/rng/rng.py
+++ b/dockercoins/rng/rng.py
@@ -28,5 +28,5 @@ def rng(how_many_bytes):
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=80)
+    app.run(host="0.0.0.0", port=80, threaded=False)
 


### PR DESCRIPTION
I’ve been running through the self-paced version of the Kubernetes course.
After scaling the number of dockercoins workers up to 10, the slides say:
https://github.com/jpetazzo/container.training/blob/139757613b5981ba08326e6728985708f32964ea/slides/common/composescale.md#L145
...but I do see a 10x bump.

The ``time.sleep(0.1)`` in [rng](https://github.com/jpetazzo/container.training/blob/139757613b5981ba08326e6728985708f32964ea/dockercoins/rng/rng.py#L24) and the ``sleep 0.1`` in [hasher](https://github.com/jpetazzo/container.training/blob/139757613b5981ba08326e6728985708f32964ea/dockercoins/hasher/hasher.rb#L10) inject latency into each request. However, they do not limit the throughput of either component (to the extent described in the slides anyway) as they are multi-threaded. So the bottleneck continues to be the workers.

This can easily be confirmed:
````
$ cd container.training/dockercoins/rng/
$ docker build . -t dockercoins_rng
$ docker run -dP dockercoins_rng
$ ab -n 100 -c 100 http://$(docker port $(docker ps -lq) 80)/1

Concurrency Level:      100
Time taken for tests:   0.202 seconds
Requests per second:    495.58 [#/sec] (mean)
Time per request:       2.018 [ms] (mean, across all concurrent requests)
````

I get the impression that rng is supposed to / used to be single threaded though. The effect it would have on the throughput rate would be consistent with only seeing a ~3x speed bump. The httping test, in the "Measuring latency under load" section, would make sense then too - rng and hasher both currently return a ping latency of 1-2ms, but forcing rng to be single threaded causes its ping latency to increase to ~800ms.

Indeed, a quick investigation into the Flask library used by rng shows that since version 1.0 (released 26th April 2018), Flask has [defaulted to being multi-threaded](https://github.com/pallets/flask/commit/3738f7ff99661fa0319ebe2d8228ad8c479fb46a). So prior to that rng will have been single threaded.

Rather than pin the version of Flask used by rng to 0.12.4, I'm suggesting passing an argument to force it to be single threaded instead:
````python
app.run(host="0.0.0.0", port=80, threaded=False)
````

With this fix, rng's behaviour reverts back to what I assume it was previously:
````
Concurrency Level:      100
Time taken for tests:   10.194 seconds
Requests per second:    9.81 [#/sec] (mean)
Time per request:       101.941 [ms] (mean, across all concurrent requests)
````