### PR TITLE
Ensure idempotence

### DIFF
--- a/prepare-vms/lib/commands.sh
+++ b/prepare-vms/lib/commands.sh
@@ -139,6 +139,7 @@ _cmd_kube() {
 
     # Initialize kube master
     pssh --timeout 200 "
+    sudo kubeadm reset -f
     if grep -q node1 /tmp/node && [ ! -f /etc/kubernetes/admin.conf ]; then
         kubeadm token generate > /tmp/token
 	sudo kubeadm init --token \$(cat /tmp/token)

--- a/prepare-vms/lib/postprep.py
+++ b/prepare-vms/lib/postprep.py
@@ -114,6 +114,9 @@ system("sudo apt-get -qy install python-setuptools pssh apache2-utils httping ht
 ### (If we don't do this, Docker will not be responsive during the next step.)
 system("while ! sudo -u docker docker version ; do sleep 2; done")
 
+### Clean up any previous hosts
+system("cat /etc/hosts | grep -v node | sudo tee /etc/hosts")
+
 ### BEGIN CLUSTERING ###
 
 addresses = list(l.strip() for l in sys.stdin)


### PR DESCRIPTION
When I had an off-by-one error in the IPs file, I ended up with unexpected results:

* The /etc/hosts file would preserve incorrect previous mappings of nodeN and an IP (and this is a problem if they must be grouped correctly to be able to reach each other, for security-group reasons)

* k8s would preserve previous erroneous attempts at cluster configuration

This is my attempt to make a re-run with a group of different IPs actually succeed. Works in my testing but I'm interested in what you think, @jpetazzo.