### PR TITLE
Cloud-agnostic; mentioning multiple clouds

### DIFF
--- a/slides/kube/concepts-k8s.md
+++ b/slides/kube/concepts-k8s.md
@@ -161,7 +161,7 @@ class: pic
 
   (This is illustrated on the first "super complicated" schema)
 
-- In some hosted Kubernetes offerings (e.g. GKE), the control plane is invisible
+- In some hosted Kubernetes offerings (e.g. AKS, GKE, EKS), the control plane is invisible
 
   (We only "see" a Kubernetes API endpoint)
 


### PR DESCRIPTION
If we're going to name GKE here, it probably makes sense (since their offerings now exist) to mention the other clouds too. Feel free to re-arrange order/wording if you like this idea and just want to explain it differently.