### PR TITLE
Mention progressDeadlineSeconds

### DIFF
--- a/slides/kube/daemonset.md
+++ b/slides/kube/daemonset.md
@@ -130,6 +130,7 @@ We all knew this couldn't be that easy, right!
 
   - remove the `replicas` field
   - remove the `strategy` field (which defines the rollout mechanism for a deployment)
+  - remove the `progressDeadlineSeconds` field (also used by the rollout mechanism)
   - remove the `status: {}` line at the end
 
 --


### PR DESCRIPTION
@abuisine ran through the whole deck recently, taking the long route each time it was possible; and he noticed that another field had to be removed when transforming the Deployment into a DaemonSet.