### PR TITLE
Pre-install Stern and Helm

### DIFF
--- a/prepare-vms/lib/commands.sh
+++ b/prepare-vms/lib/commands.sh
@@ -168,6 +168,22 @@ _cmd_kube() {
         sudo kubeadm join --discovery-token-unsafe-skip-ca-verification --token \$TOKEN node1:6443
     fi"
 
+    # Install stern
+    pssh "
+    if [ ! -x /usr/local/bin/stern ]; then
+        sudo curl -L -o /usr/local/bin/stern https://github.com/wercker/stern/releases/download/1.8.0/stern_linux_amd64
+        sudo chmod +x /usr/local/bin/stern
+        stern --completion bash | sudo tee /etc/bash_completion.d/stern
+    fi"
+
+    # Install helm
+    pssh "
+    if [ ! -x /usr/local/bin/helm ]; then
+        curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | sudo bash
+        helm completion bash | sudo tee /etc/bash_completion.d/helm
+    fi"
+
+
     sep "Done"
 }
 

--- a/slides/k8s/helm.md
+++ b/slides/k8s/helm.md
@@ -34,26 +34,46 @@
 
 ## Installing Helm
 
-- We need to install the `helm` CLI; then use it to deploy `tiller`
+- If the `helm` CLI is not installed in your environment, install it
 
 .exercise[
 
-- Install the `helm` CLI:
+- Check if `helm` is installed:
+  ```bash
+  helm
+  ```
+
+- If it's not installed, run the following command:
   ```bash
   curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
   ```
 
-- Deploy `tiller`:
+]
+
+---
+
+## Installing Tiller
+
+- Tiller is composed of a *service* and a *deployment* in the `kube-system` namespace
+
+- They can be managed (installed, upgraded...) with the `helm` CLI
+
+.exercise[
+
+- Deploy Tiller:
   ```bash
   helm init
   ```
 
-- Add the `helm` completion:
-  ```bash
-  . <(helm completion $(basename $SHELL))
-  ```
-
 ]
+
+If Tiller was already installed, don't worry: this won't break it.
+
+At the end of the install process, you will see:
+
+```
+Happy Helming!
+```
 
 ---
 

--- a/slides/k8s/logs-cli.md
+++ b/slides/k8s/logs-cli.md
@@ -47,22 +47,24 @@ Exactly what we need!
 
 ## Installing Stern
 
-- For simplicity, let's just grab a binary release
+- Run `stern` (without arguments) to check if it's installed:
 
-.exercise[
+  ```
+  $ stern
+  Tail multiple pods and containers from Kubernetes
 
-- Download a binary release from GitHub:
-  ```bash
-  sudo curl -L -o /usr/local/bin/stern \
-       https://github.com/wercker/stern/releases/download/1.6.0/stern_linux_amd64
-  sudo chmod +x /usr/local/bin/stern
+  Usage:
+    stern pod-query [flags]
   ```
 
-]
+- If it is not installed, the easiest method is to download a [binary release](https://github.com/wercker/stern/releases)
 
-These installation instructions will work on our clusters, since they are Linux amd64 VMs.
-
-However, you will have to adapt them if you want to install Stern on your local machine.
+- The following commands will install Stern on a Linux Intel 64 bits machine:
+  ```bash
+  sudo curl -L -o /usr/local/bin/stern \
+       https://github.com/wercker/stern/releases/download/1.8.0/stern_linux_amd64
+  sudo chmod +x /usr/local/bin/stern
+  ```
 
 ---
 


### PR DESCRIPTION
The commands to install Stern and Helm aren't super exciting,
so let's pre-install these tools. That way, we also generate
completion for them. We still give installation instructions
just in case, but this saves time for more important stuff.