### PR TITLE
remove compose teaser

### DIFF
--- a/slides/containers/Local_Development_Workflow.md
+++ b/slides/containers/Local_Development_Workflow.md
@@ -309,54 +309,6 @@ and *canary deployments*.
 
 ---
 
-## Improving the workflow
-
-The workflow that we showed is nice, but it requires us to:
-
-* keep track of all the `docker run` flags required to run the container,
-
-* inspect the `Dockerfile` to know which path(s) to mount,
-
-* write scripts to hide that complexity.
-
-There has to be a better way!
-
----
-
-## Docker Compose to the rescue
-
-* Docker Compose allows us to "encode" `docker run` parameters in a YAML file.
-
-* Here is the `docker-compose.yml` file that we can use for our "namer" app:
-
-  ```yaml
-  www:
-    build: .
-    volumes:
-      - .:/src
-    ports:
-      - 80:9292
-  ```
-
-* Try it:
-  ```bash
-  $ docker-compose up -d
-  ```
-
----
-
-## Working with Docker Compose
-
-* When you see a `docker-compose.yml` file, you can use `docker-compose up`.
-
-* It can build images and run them with the required parameters.
-
-* Compose can also deal with complex, multi-container apps.
-
-  (More on this later!)
-
----
-
 ## Recap of the development workflow
 
 1. Write a Dockerfile to build an image containing our development environment.


### PR DESCRIPTION
We have a whole section on `Compose_For_Dev_Stacks.md` and these two slides I'm cutting in an earlier lecture are a context shift in the middle of talking about `docker run` workflow, and for the sake of timing I've found it doesn't add value to "tease" about compose early on, so to save time and potential issues like "I don't have docker-compose on Linux" (which is addressed in compose lecture) I'm suggesting we remove these few slides.