### PR TITLE
Clarify kubens

### DIFF
--- a/slides/k8s/namespaces.md
+++ b/slides/k8s/namespaces.md
@@ -205,7 +205,9 @@ Note: it might take a minute or two for the app to be up and running.
   kubectl config set-context --current --namespace=foo
   ```
 
-- We can also use a little helper tool called `kubens`:
+- We can also use a little helper tool called `kubens`.
+
+  (These examples are for illustration, and are not functional.)
 
   ```bash
   # Switch to namespace foo


### PR DESCRIPTION
Clarify (and yes, this doesn't solve all cases of "what to type when") - but this one in particular might be confusing because the commands aren't installed under those names, which is explained on a later page.