### PR TITLE
fixes workshopctl commands needing --infra

### DIFF
--- a/prepare-vms/lib/commands.sh
+++ b/prepare-vms/lib/commands.sh
@@ -226,7 +226,7 @@ _cmd_ids() {
 
 _cmd list "List available groups for a given infrastructure"
 _cmd_list() {
-    need_infra $1
+    need_infra $2
     infra_list
 }
 
@@ -272,7 +272,7 @@ EOF
 
 _cmd opensg "Open the default security group to ALL ingress traffic"
 _cmd_opensg() {
-    need_infra $1
+    need_infra $2
     infra_opensg
 }
 
@@ -294,7 +294,7 @@ _cmd_pull_images() {
 
 _cmd quotas "Check our infrastructure quotas (max instances)"
 _cmd_quotas() {
-    need_infra $1
+    need_infra $2
     infra_quotas
 }
 


### PR DESCRIPTION
commands like opensg and quotas need the `--infra` file but weren't getting the filename from cli correctly. This fixes that.