### PR TITLE
#393 slides about portainer api

### DIFF
--- a/slides/swarm/gui.md
+++ b/slides/swarm/gui.md
@@ -49,3 +49,53 @@ What about web interfaces to control and manage Swarm?
   - Agent URL: `tasks.agent:9001`
 
 - Let's browse around the interface
+
+---
+
+## Portainer API - Advanced privileges
+
+- setup a non administrative user
+
+- deploy an app template via portainer with only administrator rights
+
+- deploy an app template via portainer with rights for the created user
+
+- do `http POST :9000/api/auth Username="$USER" Password="$PASSWORD"`
+
+- now try to query the deployed stacks `http GET :9000/api/stacks "Authorization: Bearer $TOKEN"`
+  you will only see the stack with the user rights
+
+---
+
+## Single GUI/API for multiple swarms
+
+- setup 2 swarms instead of one swarm with 3 nodes
+
+- install the portainer agent on both swarms
+
+```
+docker service create \
+    --name portainer_agent \
+    --network portainer_agent_network \
+    --publish mode=host,target=9001,published=9001 \
+    -e AGENT_CLUSTER_ADDR=tasks.portainer_agent \
+    --mode global \
+    --mount type=bind,src=//var/run/docker.sock,dst=/var/run/docker.sock \
+    --mount type=bind,src=//var/lib/docker/volumes,dst=/var/lib/docker/volumes \
+    portainer/agent
+```
+
+- now go to portainer and add both agents as endpoint
+
+- now you can deploy stacks via one api on multiple docker swarms
+
+- deploy a stack on swarm2
+
+```
+http POST ':9000/api/stacks?method=repository&type=1&endpointId=2' \
+  "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwidXNlcm5hbWUiOiJ1c2VyMSIsInJvbGUiOjIsImV4cCI6MTU0MTQ5MDg4OH0.9hVYxfSfdNAnQDRfEsH9-EcQkI9aL3beEmxJz8_6uOI" \
+  Name="Voting" \
+  RepositoryURL="https://github.com/BretFisher/example-voting-app" \
+  ComposeFilePathInRepository="docker-stack.yml" \
+  SwarmID="$SWARMID"
+```

--- a/slides/swarm/gui.md
+++ b/slides/swarm/gui.md
@@ -65,6 +65,8 @@ What about web interfaces to control and manage Swarm?
 - now try to query the deployed stacks `http GET :9000/api/stacks "Authorization: Bearer $TOKEN"`
   you will only see the stack with the user rights
 
+- you could prevent access for stacks like monitoring, log-forwarding and the portainer agent
+
 ---
 
 ## Single GUI/API for multiple swarms


### PR DESCRIPTION
I tried to add 2 slides to demonstrate 2 of the major benefits of the portainer API.

1. You will get a privilege management (not an API exclusive benefit) 

You can not can restrict almost all resources to teams/users.

That will allow you to setup a docker-swarm as administrator. Deploy some "infrastructure"-stacks for logging, monitoring and the portainer agent but restrict the access to these stacks only to administration-users. 

"Normal" Users/Teams cannot edit/remove these stacks. 

2. You can use the API to deploy stacks on different swarms via one entrypoint.

This gets really big, when you start adding multiple swarms to portainer. You just have to deploy the portainer agent on the swarms you want to manage. Have one docker-swarm for all your management stuff and several for processing.

With the privilege mangement, you can now give teams access to selected swarms. This all applies also to the API. So your teams can now deploy stacks via CI with HTTP on selected swarms not affecting swarms of other teams via a single "PAAS" entrypoint. 

One thing you can only do with the portainer API is the deployment of a stack from a git repository. So you don't have to handle local docker-compose files or post the compose-data into the API. You can just give the API a path to a docker-compose-file in a git-repository. There is a downside. You cannot use config or env files at this moment. 