### PR TITLE
Ignore 'wrong Docker version' warning

### DIFF
--- a/prepare-vms/lib/commands.sh
+++ b/prepare-vms/lib/commands.sh
@@ -123,7 +123,9 @@ _cmd_kube() {
     pssh --timeout 200 "
     if grep -q node1 /tmp/node && [ ! -f /etc/kubernetes/admin.conf ]; then
         kubeadm token generate > /tmp/token &&
-	sudo kubeadm init --token \$(cat /tmp/token)
+	sudo kubeadm init \
+             --token \$(cat /tmp/token) \
+             --ignore-preflight-errors=SystemVerification
     fi"
 
     # Put kubeconfig in ubuntu's and docker's accounts
@@ -147,7 +149,10 @@ _cmd_kube() {
     pssh --timeout 200 "
     if ! grep -q node1 /tmp/node && [ ! -f /etc/kubernetes/kubelet.conf ]; then
         TOKEN=\$(ssh -o StrictHostKeyChecking=no node1 cat /tmp/token) &&
-        sudo kubeadm join --discovery-token-unsafe-skip-ca-verification --token \$TOKEN node1:6443
+        sudo kubeadm join \
+             --discovery-token-unsafe-skip-ca-verification \
+             --ignore-preflight-errors=SystemVerification \
+             --token \$TOKEN node1:6443
     fi"
 
     # Install kubectx and kubens


### PR DESCRIPTION
For some reason, kubeadm doesn't want to deploy with Docker Engine 18.09.
Before, it would just issue a warning; but now apparently the warning blocks
the deployment. So... let's ignore the warning. (I've tested the content
and it works fine with Engine 18.09 as far as I can tell.)

@bridgetkromhout, any thoughts on that? (If you have concerns, we can hold
merging this.)