### PR TITLE
Bump all the versions

### DIFF
--- a/prepare-vms/lib/commands.sh
+++ b/prepare-vms/lib/commands.sh
@@ -170,7 +170,8 @@ EOF"
     # Install stern
     pssh "
     if [ ! -x /usr/local/bin/stern ]; then
-        sudo curl -L -o /usr/local/bin/stern https://github.com/wercker/stern/releases/download/1.8.0/stern_linux_amd64 &&
+        ##VERSION##
+        sudo curl -L -o /usr/local/bin/stern https://github.com/wercker/stern/releases/download/1.10.0/stern_linux_amd64 &&
         sudo chmod +x /usr/local/bin/stern &&
         stern --completion bash | sudo tee /etc/bash_completion.d/stern
     fi"

--- a/prepare-vms/lib/infra/aws.sh
+++ b/prepare-vms/lib/infra/aws.sh
@@ -201,5 +201,6 @@ aws_tag_instances() {
 }
 
 aws_get_ami() {
-    find_ubuntu_ami -r $AWS_DEFAULT_REGION -a amd64 -v 16.04 -t hvm:ebs -N -q
+    ##VERSION##
+    find_ubuntu_ami -r $AWS_DEFAULT_REGION -a amd64 -v 18.04 -t hvm:ebs -N -q
 }

--- a/slides/k8s/logs-cli.md
+++ b/slides/k8s/logs-cli.md
@@ -62,9 +62,11 @@ Exactly what we need!
 - The following commands will install Stern on a Linux Intel 64 bit machine:
   ```bash
   sudo curl -L -o /usr/local/bin/stern \
-       https://github.com/wercker/stern/releases/download/1.8.0/stern_linux_amd64
+       https://github.com/wercker/stern/releases/download/1.10.0/stern_linux_amd64
   sudo chmod +x /usr/local/bin/stern
   ```
+
+<!-- ##VERSION## -->
 
 ---
 

--- a/slides/k8s/setup-k8s.md
+++ b/slides/k8s/setup-k8s.md
@@ -4,7 +4,9 @@
 
 --
 
-- We used `kubeadm` on freshly installed VM instances running Ubuntu 16.04 LTS
+<!-- ##VERSION## -->
+
+- We used `kubeadm` on freshly installed VM instances running Ubuntu 18.04 LTS
 
     1. Install Docker
 

--- a/slides/k8s/versions-k8s.md
+++ b/slides/k8s/versions-k8s.md
@@ -1,9 +1,10 @@
 ## Versions installed
 
-- Kubernetes 1.12.0
-- Docker Engine 18.06.1-ce
+- Kubernetes 1.12.2
+- Docker Engine 18.09.0
 - Docker Compose 1.21.1
 
+<!-- ##VERSION## -->
 
 .exercise[
 


### PR DESCRIPTION
Bump:
- stern
- Ubuntu

Also, each place where there is a 'bumpable' version, I added
a ##VERSION## marker, easily greppable.

@bridgetkromhout @BretFisher I've tested the k8s content with Ubuntu 18.04 but not the Swarm content. Let me know if you have concerns about bumping our base image and what you'd like me to do to merge in confidence!