### PR TITLE
Support multi-day events

### DIFF
--- a/slides/index.py
+++ b/slides/index.py
@@ -106,25 +106,40 @@ import yaml
 
 items = yaml.load(open("index.yaml"))
 
+# Items with a date correspond to scheduled sessions.
+# Items without a date correspond to self-paced content.
+# The date should be specified as a string (e.g. 2018-11-26).
+# It can also be a list of two elements (e.g. [2018-11-26, 2018-11-28]).
+# The latter indicates an event spanning multiple dates.
+# The first date will be used in the generated page, but the event
+# will be considered "current" (and therefore, shown in the list of
+# upcoming events) until the second date.
+
 for item in items:
     if "date" in item:
         date = item["date"]
+        if type(date) == list:
+            date_begin, date_end = date
+        else:
+            date_begin, date_end = date, date
         suffix = {
                 1: "st", 2: "nd", 3: "rd",
                 21: "st", 22: "nd", 23: "rd",
-                31: "st"}.get(date.day, "th")
+                31: "st"}.get(date_begin.day, "th")
         # %e is a non-standard extension (it displays the day, but without a
         # leading zero). If strftime fails with ValueError, try to fall back
         # on %d (which displays the day but with a leading zero when needed).
         try:
-            item["prettydate"] = date.strftime("%B %e{}, %Y").format(suffix)
+            item["prettydate"] = date_begin.strftime("%B %e{}, %Y").format(suffix)
         except ValueError:
-            item["prettydate"] = date.strftime("%B %d{}, %Y").format(suffix)
+            item["prettydate"] = date_begin.strftime("%B %d{}, %Y").format(suffix)
+        item["begin"] = date_begin
+        item["end"] = date_end
 
 today = datetime.date.today()
-coming_soon = [i for i in items if i.get("date") and i["date"] >= today]
-coming_soon.sort(key=lambda i: i["date"])
-past_workshops = [i for i in items if i.get("date") and i["date"] < today]
+coming_soon = [i for i in items if i.get("date") and i["end"] >= today]
+coming_soon.sort(key=lambda i: i["begin"])
+past_workshops = [i for i in items if i.get("date") and i["end"] < today]
 past_workshops.sort(key=lambda i: i["date"], reverse=True)
 self_paced = [i for i in items if not i.get("date")]
 recorded_workshops = [i for i in items if i.get("video")]

--- a/slides/index.yaml
+++ b/slides/index.yaml
@@ -1,4 +1,4 @@
-- date: 2019-01-07
+- date: [2019-01-07, 2019-01-08]
   country: fr
   city: Paris
   event: ENIX SAS
@@ -7,7 +7,7 @@
   lang: fr
   attend: https://enix.io/fr/services/formation/bien-demarrer-avec-les-conteneurs/
 
-- date: 2018-12-17
+- date: [2018-12-17, 2018-12-18]
   country: fr
   city: Paris
   event: ENIX SAS


### PR DESCRIPTION
In index.yaml, the date can now be specified as a range. For instance,
instead of:

```yaml
date: 2018-11-28
```
We can use:

```yaml
date: [2018-11-28, 2018-12-05]
```

For now, only the start date is shown (so the event still appears
as happening on 2018-11-28 in that example), but it will be considered
"current" (and show up in the list of "coming soon" events) until
the end date.

This way, when updating the content during a multi-day event, the
event stays in the top list and is not pushed to the "past events"
section.

Single-day events can still use the old syntax, of course.

/cc @bridgetkromhout and @BretFisher for your consideration ;-)