### PR TITLE
Improve namespace switching example

### DIFF
--- a/slides/k8s/namespaces.md
+++ b/slides/k8s/namespaces.md
@@ -68,7 +68,7 @@
   kubectl -n blue get svc
   ```
 
-- We can also use *contexts*
+- We can also change our current *context*
 
 - A context is a *(user, cluster, namespace)* tuple
 
@@ -76,9 +76,9 @@
 
 ---
 
-## Creating a context
+## Viewing existing contexts
 
-- We are going to create a context for the `blue` namespace
+- On our training environments, at this point, there should be only one context
 
 .exercise[
 
@@ -87,29 +87,79 @@
   kubectl config get-contexts
   ```
 
-- Create a new context:
+]
+
+- The current context (the only one!) is tagged with a `*`
+
+- What are NAME, CLUSTER, AUTHINFO, and NAMESPACE?
+
+---
+
+## What's in a context
+
+- NAME is an arbitrary string to identify the context
+
+- CLUSTER is a reference to a cluster
+
+  (i.e. API endpoint URL, and optional certificate)
+
+- AUTHINFO is a reference to the authentication information to use
+
+  (i.e. a TLS client certificate, token, or otherwise)
+
+- NAMESPACE is the namespace
+
+  (empty string = `default`)
+
+---
+
+## Switching contexts
+
+- We want to use a different namespace
+
+- Solution 1: update the current context
+
+  *This is appropriate if we need to change just one thing (e.g. namespace or authentication).*
+
+- Solution 2: create a new context and switch to it
+
+  *This is appropriate if we need to change multiple things and switch back and forth.*
+
+- Let's go with solution 1!
+
+---
+
+## Updating a context
+
+- This is done through `kubectl config set-context`
+
+- We can update a context by passing its name, or the current context with `--current`
+
+.exercise[
+
+- Update the current context to use the `blue` namespace:
   ```bash
-  kubectl config set-context blue --namespace=blue \
-      --cluster=kubernetes --user=kubernetes-admin
+  kubectl config set-context --current --namespace=blue
+  ```
+
+- Check the result:
+  ```bash
+  kubectl config get-contexts
   ```
 
 ]
 
-We have created a context; but this is just some configuration values.
-
-The namespace doesn't exist yet.
-
 ---
 
-## Using a context
+## Using our new namespace
 
-- Let's switch to our new context and deploy the DockerCoins chart
+- Let's check that we are in our new namespace, then deploy the DockerCoins chart
 
 .exercise[
 
-- Use the `blue` context:
+- Verify that the new context is empty:
   ```bash
-  kubectl config use-context blue
+  kubectl get all
   ```
 
 - Deploy DockerCoins:
@@ -181,29 +231,18 @@ Note: it might take a minute or two for the app to be up and running.
 
 .exercise[
 
-- View the names of the contexts:
-  ```bash
-  kubectl config get-contexts
-  ```
-
 - Switch back to the original context:
   ```bash
-  kubectl config use-context kubernetes-admin@kubernetes
+  kubectl config set-context --current --namespace=
   ```
 
 ]
 
+Note: we could have used `--namespace=default` for the same result.
+
 ---
 
 ## Switching namespaces more easily
-
-- Defining a new context for each namespace can be cumbersome
-
-- We can also alter the current context with this one-liner:
-
-  ```bash
-  kubectl config set-context --current --namespace=foo
-  ```
 
 - We can also use a little helper tool called `kubens`:
 


### PR DESCRIPTION
We show how to change namespace by creating a new context, then
switching to the new context. It works, but it is very cumbersome.
Instead, let's just update the current context, and give some
details about when it's better to update the current context, and
when it is better to use different contexts and hop between them.