### PR TITLE
Update the validated docker versions list ...

### DIFF
--- a/slides/k8s/versions-k8s.md
+++ b/slides/k8s/versions-k8s.md
@@ -23,7 +23,7 @@ class: extra-details
 
 ## Kubernetes and Docker compatibility
 
-- Kubernetes 1.12.x only validates Docker Engine versions [1.11.2 to 1.13.1 and 17.03.x](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md#external-dependencies)
+- Kubernetes 1.12.x only validates Docker Engine versions [1.11.2 to 1.13.1 and 17.03.x to 18.06](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md#external-dependencies)
 
 --
 


### PR DESCRIPTION
... to include: 17.03.x to 18.06 (for k8s v1.12)

This list has changed in k8s v1.12:
* https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md#external-dependencies