### PR TITLE
strange chars instead of emojis, fixed by adding charset header

### DIFF
--- a/slides/index.py
+++ b/slides/index.py
@@ -4,6 +4,7 @@ TEMPLATE="""<html>
 <head>
   <title>{{ title }}</title>
   <link rel="stylesheet" href="index.css">
+  <meta charset="UTF-8">
 </head>
 <body>
   <div class="main">


### PR DESCRIPTION
I'm on a mac just updated to Mojave, using chrome.  Slides landing page looks like this:

![screen shot 2018-12-11 at 1 27 19 pm](https://user-images.githubusercontent.com/3408465/49821481-8b385e80-fd48-11e8-8f64-605995ce94b8.png)

Adding the charset=UTF-8 meta header on the html fixes this resulting in:
![screen shot 2018-12-11 at 1 26 39 pm](https://user-images.githubusercontent.com/3408465/49821482-8b385e80-fd48-11e8-92dd-5903a5c2fbc2.png)
