### PR TITLE
fix kubectl CLI error

### DIFF
--- a/slides/k8s/gitworkflows.md
+++ b/slides/k8s/gitworkflows.md
@@ -112,7 +112,6 @@
 - Display that key:
   ```
   kubectl logs deployment/flux | grep identity
-  
   ```
 
 - Then add that key to the repository, giving it **write** access

--- a/slides/k8s/gitworkflows.md
+++ b/slides/k8s/gitworkflows.md
@@ -111,7 +111,8 @@
 
 - Display that key:
   ```
-  kubectl logs deployment flux | grep identity
+  kubectl logs deployment/flux | grep identity
+  
   ```
 
 - Then add that key to the repository, giving it **write** access


### PR DESCRIPTION
I was getting 

```
Error from server (NotFound): pods "deployment" not found
```

here is the output of `kubectl version`

```
$ kubectl version --client -o yaml
clientVersion:
  buildDate: "2019-02-28T13:37:52Z"
  compiler: gc
  gitCommit: c27b913fddd1a6c480c229191a087698aa92f0b1
  gitTreeState: clean
  gitVersion: v1.13.4
  goVersion: go1.11.5
  major: "1"
  minor: "13"
  platform: linux/amd64
