### PR TITLE
Update the slides introducing namespaces and kube-public

### DIFF
--- a/slides/k8s/kubectlget.md
+++ b/slides/k8s/kubectlget.md
@@ -108,7 +108,7 @@
 
 - The API documentation is usually easier to read, but:
 
-  - it won't show custom types (like Custom Ressource Definitions)
+  - it won't show custom types (like Custom Resource Definitions)
 
   - we need to make sure that we look at the correct version
 

--- a/slides/k8s/kubectlget.md
+++ b/slides/k8s/kubectlget.md
@@ -290,7 +290,7 @@ The error that we see is expected: the Kubernetes API requires authentication.
 
 - Since Kubernetes 1.14, we can also use `-A` as a shorter version:
   ```bash
-  kuectl get pods -A
+  kubectl get pods -A
   ```
 
 ]
@@ -441,4 +441,4 @@ class: extra-details
 
 - This file *does not* hold client keys or tokens
 
-- This is not sensitive information, but allows to establish trust
+- This is not sensitive information, but allows us to establish trust


### PR DESCRIPTION
1) When introducing "kubectl describe", we ask people to
   look at "kubectl describe node node1", which shows
   them a bunch of pods. This makes it easier to contrast
   with the (empty) output of "kubectl get pods" later.

2) Then, instead of going straight to "-n kube-system",
   we introduce "--all-namespaces" to show pods across
   all namespaces. Of course we also mention "-n" and
   we also explain when these flags can be used.

3) Finally, I rewrote the section about kube-public,
   because it was misleading. It pointed at the Secret
   in kube-public, but that Secret merely corresponds
   to the token automatically created for the default
   ServiceAccount in that namespace. Instead, it's
   more relevant to look at the ConfigMap cluster-info,
   which contains a kubeconfig data piece.

The last item gives us an opportunity to talk to the
API with curl, because that cluster-info ConfigMap is
a public resource.