### PR TITLE
Improve "slides/Dockerfile" reliability/image size

### DIFF
--- a/slides/Dockerfile
+++ b/slides/Dockerfile
@@ -1,7 +1,4 @@
-FROM alpine
-RUN apk update
-RUN apk add entr
-RUN apk add py-pip
-RUN apk add git
+FROM alpine:3.9
+RUN apk add --no-cache entr py-pip git
 COPY requirements.txt .
 RUN pip install -r requirements.txt


### PR DESCRIPTION
This pins to a specific version of Alpine to insulate against Alpine version bumps renaming packages (or changing the way they work like when `pip` got split out into a separate package) and uses `apk add --no-cache` instead of `apk update` to create a slightly smaller end result.