### PR TITLE
Consistent naming

### DIFF
--- a/slides/k8s/resource-limits.md
+++ b/slides/k8s/resource-limits.md
@@ -404,7 +404,7 @@ These quotas will apply to the namespace where the ResourceQuota is created.
 
 - Example:
   ```bash
-  kubectl create quota sparta --hard=pods=300,limits.memory=300Gi
+  kubectl create quota my-resource-quota --hard=pods=300,limits.memory=300Gi
   ```
 
 - With both YAML and CLI form, the values are always under the `hard` section


### PR DESCRIPTION
I found the reference to `sparta` confusing since shortly thereafter on the very next page, it's got a different name. Unless there was a reason I don't understand, I think this is better:

```
- Example:
  ```bash
  kubectl create quota my-resource-quota --hard=pods=300,limits.memory=300Gi
  ```

- With both YAML and CLI form, the values are always under the `hard` section

  (there is no `soft` quota)

---

## Viewing current usage

When a ResourceQuota is created, we can see how much of it is used:

```
kubectl describe resourcequota my-resource-quota

```