### PR TITLE
Fixing broken link

### DIFF
--- a/slides/k8s/setup-managed.md
+++ b/slides/k8s/setup-managed.md
@@ -144,7 +144,7 @@ with a cloud provider
   az login
   ```
 
-- Select a [region](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=kubernetes-service\&regions=all
+- Select a [region](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=kubernetes-service&regions=all
 )
 
 - Create a "resource group":


### PR DESCRIPTION
This link doesn't do so well when escaped. Check it out here: https://kadm-2019-06.container.training/#213 - I get 

```
https://azure.microsoft.com/en-us/global-infrastructure/services/?products=kubernetes-service\%C2%AEions=all
```