### PR TITLE
Update Flux github url

### DIFF
--- a/slides/k8s/gitworkflows.md
+++ b/slides/k8s/gitworkflows.md
@@ -87,7 +87,7 @@
 
 - Clone the Flux repository:
   ```
-  git clone https://github.com/weaveworks/flux
+  git clone https://github.com/fluxcd/flux
   ```
 
 - Edit `deploy/flux-deployment.yaml`


### PR DESCRIPTION
Flux repo has moved: https://github.com/fluxcd/flux/wiki/MoveToFluxCD