### PR TITLE
highlight code that is recommended to be used

### DIFF
--- a/slides/k8s/buildshiprun-dockerhub.md
+++ b/slides/k8s/buildshiprun-dockerhub.md
@@ -34,6 +34,8 @@
 
 - For example:
 
-  `export REGISTRY=dockercoins TAG=v0.1`
+  ```bash
+  export REGISTRY=dockercoins TAG=v0.1
+  ```
 
   (this will expand `$REGISTRY/worker:$TAG` to `dockercoins/worker:v0.1`)

--- a/slides/k8s/buildshiprun-dockerhub.md
+++ b/slides/k8s/buildshiprun-dockerhub.md
@@ -33,7 +33,6 @@
   **make sure that you set `$REGISTRY` and `$TAG` first!**
 
 - For example:
-
   ```bash
   export REGISTRY=dockercoins TAG=v0.1
   ```

--- a/slides/k8s/buildshiprun-dockerhub.md
+++ b/slides/k8s/buildshiprun-dockerhub.md
@@ -33,8 +33,7 @@
   **make sure that you set `$REGISTRY` and `$TAG` first!**
 
 - For example:
-  ```
-  export REGISTRY=dockercoins TAG=v0.1
-  ```
+
+  `export REGISTRY=dockercoins TAG=v0.1`
 
   (this will expand `$REGISTRY/worker:$TAG` to `dockercoins/worker:v0.1`)


### PR DESCRIPTION
Multi line code blocks are not highlighted in any way in the slides.
Switching to single line code makes it more visible.