### PR TITLE
fixing uppercase K in yaml for static pods

### DIFF
--- a/k8s/just-a-pod.yaml
+++ b/k8s/just-a-pod.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-Kind: Pod
+kind: Pod
 metadata:
   name: hello
   namespace: default

--- a/slides/k8s/staticpods.md
+++ b/slides/k8s/staticpods.md
@@ -224,7 +224,7 @@ In the manifest, the pod was named `hello`.
 
 ```yaml
 apiVersion: v1
-Kind: Pod
+kind: Pod
 metadata:
   name: hello
   namespace: default


### PR DESCRIPTION
`Kind` will cause a validation error if using `kubectl apply` on this file. Also updated markdown example.