### PR TITLE
Os x stern install

### DIFF
--- a/slides/k8s/logs-cli.md
+++ b/slides/k8s/logs-cli.md
@@ -65,7 +65,8 @@ Exactly what we need!
        https://github.com/wercker/stern/releases/download/1.11.0/stern_linux_amd64
   sudo chmod +x /usr/local/bin/stern
   ```
-  On OS X, `brew install stern`
+
+- On OS X, just `brew install stern`
 
 <!-- ##VERSION## -->
 

--- a/slides/k8s/logs-cli.md
+++ b/slides/k8s/logs-cli.md
@@ -65,6 +65,7 @@ Exactly what we need!
        https://github.com/wercker/stern/releases/download/1.11.0/stern_linux_amd64
   sudo chmod +x /usr/local/bin/stern
   ```
+  On OS X, `brew install stern`
 
 <!-- ##VERSION## -->
 


### PR DESCRIPTION
Adds a line to the slide the describes installing `stern` that gives the correct `brew` invocation for OS X.