### PR TITLE
remove deprecated rkt, mention runtimes are different per distro

### DIFF
--- a/slides/containers/Container_Engines.md
+++ b/slides/containers/Container_Engines.md
@@ -104,22 +104,6 @@ like Windows, macOS, Solaris, FreeBSD ...
 
 ---
 
-## rkt
-
-* Compares to `runc`.
-
-* No daemon or API.
-
-* Strong emphasis on security (through privilege separation).
-
-* Networking has to be set up separately (e.g. through CNI plugins).
-
-* Partial image management (pull, but no push).
-
-  (Image build is handled by separate tools.)
-
----
-
 ## CRI-O
 
 * Designed to be used with Kubernetes as a simple, basic runtime.

--- a/slides/k8s/concepts-k8s.md
+++ b/slides/k8s/concepts-k8s.md
@@ -193,9 +193,19 @@ No!
 
 - Or leverage other pluggable runtimes through the *Container Runtime Interface*
 
-  (like CRI-O, or containerd)
+- <del>We could also use `rkt` ("Rocket") from CoreOS</del> (deprecated)
 
-- Different install methods and distributions use different runtimes
+- [containerd](https://github.com/containerd/containerd/blob/master/README.md):
+maintained by Docker, IBM, and community
+
+- Used by Docker Engine, microK8s, k3s, GKE, and standalone. Has `ctr` CLI
+
+- [CRI-O](https://github.com/cri-o/cri-o/blob/master/README.md):
+maintained by Red Hat, SUSE, and community. Based on containerd
+
+- Used by OpenShift and Kubic, version matched to Kubernetes
+
+- [And more](https://kubernetes.io/docs/setup/production-environment/container-runtimes/)
 
 ---
 

--- a/slides/k8s/concepts-k8s.md
+++ b/slides/k8s/concepts-k8s.md
@@ -191,19 +191,27 @@ No!
 
 - By default, Kubernetes uses the Docker Engine to run containers
 
-- Or leverage other pluggable runtimes through the *Container Runtime Interface*
+- We can leverage other pluggable runtimes through the *Container Runtime Interface*
 
 - <del>We could also use `rkt` ("Rocket") from CoreOS</del> (deprecated)
 
-- [containerd](https://github.com/containerd/containerd/blob/master/README.md):
-maintained by Docker, IBM, and community
+---
 
-- Used by Docker Engine, microK8s, k3s, GKE, and standalone. Has `ctr` CLI
+class: extra-details
+
+## Some runtimes available through CRI
+
+- [containerd](https://github.com/containerd/containerd/blob/master/README.md)
+
+  - maintained by Docker, IBM, and community
+  - used by Docker Engine, microk8s, k3s, GKE; also standalone
+  - comes with its own CLI, `ctr`
 
 - [CRI-O](https://github.com/cri-o/cri-o/blob/master/README.md):
-maintained by Red Hat, SUSE, and community. Based on containerd
 
-- Used by OpenShift and Kubic, version matched to Kubernetes
+  - maintained by Red Hat, SUSE, and community
+  - used by OpenShift and Kubic
+  - designed specifically as a minimal runtime for Kubernetes
 
 - [And more](https://kubernetes.io/docs/setup/production-environment/container-runtimes/)
 

--- a/slides/k8s/concepts-k8s.md
+++ b/slides/k8s/concepts-k8s.md
@@ -191,11 +191,11 @@ No!
 
 - By default, Kubernetes uses the Docker Engine to run containers
 
-- We could also use `rkt` ("Rocket") from CoreOS
-
 - Or leverage other pluggable runtimes through the *Container Runtime Interface*
 
   (like CRI-O, or containerd)
+
+- Different install methods and distributions use different runtimes
 
 ---
 


### PR DESCRIPTION
Now that rkt is clearly deprecated, no need to mention it over the Kubernetes supported projects like cri-o and containerd.