### PR TITLE
update Introduction to Docker and Containers slides to fix the part with named volumes

### DIFF
--- a/slides/containers/Working_With_Volumes.md
+++ b/slides/containers/Working_With_Volumes.md
@@ -170,7 +170,7 @@ Let's start a web server using the two previous volumes.
 ```bash
 $ docker run -d -p 1234:8080 \
          -v logs:/usr/local/tomcat/logs \
-         -v webapps:/usr/local/tomcat/webapps \
+         -v webapps:/usr/local/tomcat/webapps.dist \
          tomcat
 ```
 

--- a/slides/k8s/labels-annotations.md
+++ b/slides/k8s/labels-annotations.md
@@ -190,7 +190,7 @@ class: extra-details
 
 - Label *values* are up to 63 characters, with the same restrictions
 
-- Annotations *values* can have arbitrary characeters (yes, even binary)
+- Annotations *values* can have arbitrary characters (yes, even binary)
 
 - Maximum length isn't defined
 


### PR DESCRIPTION
The Tomcat image has been updated on Docker Hub :
`Note: as of docker-library/tomcat#181, the upstream-provided (example) webapps are not enabled by default, per upstream's security recommendations, but are still available under the webapps.dist folder within the image to make them easier to re-enable.`

Hence the commands on slides 460 and 461 doesn't work as expected.

I just modified the volume of `docker run` command for the tomcat container, I don't know if it's the best thing to do.