### PR TITLE
update server-side dry run for recent kubectl

### DIFF
--- a/slides/k8s/dryrun.md
+++ b/slides/k8s/dryrun.md
@@ -124,7 +124,7 @@ The resulting YAML doesn't represent a valid DaemonSet.
 
 - Try the same YAML file as earlier, with server-side dry run:
   ```bash
-  kubectl apply -f web.yaml --server-dry-run --validate=false -o yaml
+  kubectl apply -f web.yaml --dry-run=server --validate=false -o yaml
   ```
 
 ]


### PR DESCRIPTION
Error message :
```
$ kubectl apply -f web.yaml --server-dry-run --validate=false -o yaml                                                                   
Error: unknown flag: --server-dry-run                                                                                                   
See 'kubectl apply --help' for usage.
```

Doc says: 
```
      --dry-run='none': Must be "none", "server", or "client". If client strategy, only print the object that would be                  
sent, without sending it. If server strategy, submit server-side request without persisting the resource.
```