### PR TITLE
ServiceAccount <> IAM role

### DIFF
--- a/bin/sa-can-read-s3.sh
+++ b/bin/sa-can-read-s3.sh
@@ -23,13 +23,13 @@ emit_describe_cluster_policy() {
 }
 
 create_describe_cluster_policy() {
-    local role_name="can-describe-cluster"
     aws iam create-policy \
-        --policy-name can-describe-cluster \
+        --policy-name ${DESCRIBE_CLUSTER_POLICY_NAME} \
         --description "Policy allowing to describe ${CLUSTER_NAME}" \
         --policy-document "$(emit_describe_cluster_policy)"
 
-    aws iam attach-user-policy --role-name "${role_name}" --policy-arn "${S3_POLICY_ARN}"
+    # to attach:
+    # aws iam attach-user-policy --user-name "${user_name}" --policy-arn "arn:aws:iam::${ACCOUNT_ID}:policy/${DESCRIBE_CLUSTER_POLICY_NAME}"
 }
 
 emit_service_account_role_trust_policy() {
@@ -91,6 +91,9 @@ teardown() {
     # see also 'can-describe-cluster' policy, if created via create_describe_cluster_policy
     aws iam detach-role-policy --policy-arn "${S3_POLICY_ARN}" --role-name "${ROLE_NAME}"
     aws iam delete-role "${ROLE_NAME}"
+    # for username in users; do ...
+    # aws iam detach-user-policy --policy-arn "arn:aws:iam::${ACCOUNT_ID}:policy/${DESCRIBE_CLUSTER_POLICY_NAME}" --user-name "${username}"
+    aws iam delete-policy --policy-arn "arn:aws:iam::${ACCOUNT_ID}:policy/${DESCRIBE_CLUSTER_POLICY_NAME}"
 }
 
 create_and_populate_bucket() {
@@ -107,6 +110,7 @@ create_and_populate_bucket() {
 ACCOUNT_ID="$(aws sts get-caller-identity | jq -r .Account)"
 S3_POLICY_ARN=arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
 CLUSTER_NAME=floral-mongoose-1616851817
+DESCRIBE_CLUSTER_POLICY_NAME=can-describe-cluster
 ROLE_NAME=service-account-role
 REGION=eu-north-1
 BUCKET_NAME=wooga-booga-pants

--- a/bin/sa-can-read-s3.sh
+++ b/bin/sa-can-read-s3.sh
@@ -25,7 +25,7 @@ emit_describe_cluster_policy() {
 create_describe_cluster_policy() {
     local role_name="can-describe-cluster"
     aws iam create-policy \
-        --policy-name "${role_name}" \
+        --policy-name can-describe-cluster \
         --description "Policy allowing to describe ${CLUSTER_NAME}" \
         --policy-document "$(emit_describe_cluster_policy)"
 
@@ -87,9 +87,9 @@ update_kubeconfig() {
 }
 
 teardown() {
+    # see also 'can-describe-cluster' policy, if created via create_describe_cluster_policy
     aws iam detach-role-policy --policy-arn "${S3_POLICY_ARN}" --role-name "${ROLE_NAME}"
     aws iam delete-role "${ROLE_NAME}"
-    aws iam delete-policy --policy-arn
 }
 
 create_and_populate_bucket() {

--- a/bin/sa-can-read-s3.sh
+++ b/bin/sa-can-read-s3.sh
@@ -75,7 +75,7 @@ create_role() {
 }
 
 annotate_serviceaccount() {
-    kubectl annotate serviceaccounts default -n default "role-arn=arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+    kubectl annotate serviceaccounts default -n default "role-arn=arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}" --overwrite
 }
 
 checkit() {

--- a/bin/sa-can-read-s3.sh
+++ b/bin/sa-can-read-s3.sh
@@ -79,7 +79,8 @@ annotate_serviceaccount() {
 }
 
 checkit() {
-    kubectl run --image amazon/aws-cli --attach --restart=Never --rm --wait=true herro -- s3 cp s3://"${BUCKET_NAME}"/top-sekret.txt -
+    echo "Will try to read s3://"${BUCKET_NAME}"/top-sekret.txt"
+    kubectl run --image amazon/aws-cli --attach --restart=Never --rm --wait=true can-we-read-s3 -- s3 cp s3://"${BUCKET_NAME}"/top-sekret.txt -
 }
 
 update_kubeconfig() {

--- a/bin/sa-can-read-s3.sh
+++ b/bin/sa-can-read-s3.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# I would like to demonstrate access to AWS resource (e.g. S3 bucket) from a pod. Idea:
+# create a bucket, put two objects in it (one public, one private), then … I suppose I
+# need to create a role with access to the private object, associate the role to a service
+# account in k8s, find an image with the aws CLI (or some s3 client) in it … ?
+
+set -euo pipefail
+
+emit_describe_cluster_policy() {
+    # Not used right now, but this permission is required in order to run `aws eks update-kubeconfig`:
+    echo '{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "eks:DescribeCluster"
+            ],
+            "Resource": "'"arn:aws:eks:${REGION}:${ACCOUNT_ID}:cluster/${CLUSTER_NAME}"'",
+            "Effect": "Allow"
+        }
+    ]
+}'
+}
+
+create_describe_cluster_policy() {
+    local role_name="can-describe-cluster"
+    aws iam create-policy \
+        --policy-name "${role_name}" \
+        --description "Policy allowing to describe ${CLUSTER_NAME}" \
+        --policy-document "$(emit_describe_cluster_policy)"
+
+    aws iam attach-user-policy --role-name "${role_name}" --policy-arn "${S3_POLICY_ARN}"
+}
+
+emit_service_account_role_trust_policy() {
+    local oidc_provider_arn key_prefix
+    oidc_provider_arn="$(aws iam list-open-id-connect-providers | jq -r '.OpenIDConnectProviderList[0].Arn')"
+    key_prefix="$(echo "${oidc_provider_arn}" | cut -f2- -d '/')"
+
+    echo '{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "'"${oidc_provider_arn}"'"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+            "'"${key_prefix}:sub"'": "system:serviceaccount:default:default"
+        }
+      }
+    }
+  ]
+}'
+}
+
+associate_oidc_provider() {
+    local issuer_url
+    issuer_url="$(aws eks describe-cluster --name "${CLUSTER_NAME}" --query "cluster.identity.oidc.issuer" --output text)"
+    if ! aws iam list-open-id-connect-providers | grep "${issuer_url}"; then
+        eksctl utils associate-iam-oidc-provider --cluster "${CLUSTER_NAME}" --approve
+    else
+        echo "OIDC provider already associated"
+    fi
+}
+
+create_role() {
+    if ! _="$(aws iam get-role --role-name "${ROLE_NAME}")"; then
+        aws iam create-role --role-name "${ROLE_NAME}" --description "Role for service account" --assume-role-policy-document "$(emit_service_account_role_trust_policy)"
+    else
+        echo "Role ${ROLE_NAME} already exists"
+    fi
+}
+
+annotate_serviceaccount() {
+    kubectl annotate serviceaccounts default -n default "role-arn=arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+}
+
+checkit() {
+    kubectl run --image amazon/aws-cli --attach --restart=Never --rm --wait=true herro -- s3 cp s3://"${BUCKET_NAME}"/top-sekret.txt -
+}
+
+update_kubeconfig() {
+    aws eks update-kubeconfig --name "${CLUSTER_NAME}"
+}
+
+teardown() {
+    aws iam detach-role-policy --policy-arn "${S3_POLICY_ARN}" --role-name "${ROLE_NAME}"
+    aws iam delete-role "${ROLE_NAME}"
+    aws iam delete-policy --policy-arn
+}
+
+create_and_populate_bucket() {
+    if ! _="$(aws s3api get-bucket-acl --bucket "${BUCKET_NAME}")"; then
+        aws s3api create-bucket --region "${REGION}" --bucket "${BUCKET_NAME}" --create-bucket-configuration "LocationConstraint=${REGION}"
+    else
+        echo "Bucket ${BUCKET_NAME} already exists."
+    fi
+    f="$(mktemp)"
+    echo "THE UNICORN IS IN THE GARDEN!!" >"${f}"
+    aws s3api put-object --bucket "${BUCKET_NAME}" --key top-sekret.txt --body "${f}"
+}
+
+ACCOUNT_ID="$(aws sts get-caller-identity | jq -r .Account)"
+S3_POLICY_ARN=arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+CLUSTER_NAME=floral-mongoose-1616851817
+ROLE_NAME=service-account-role
+REGION=eu-north-1
+BUCKET_NAME=wooga-booga-pants
+export KUBECONFIG=myconfig
+
+main() {
+    if [ -n "${1:-}" ]; then
+        echo "An argument was provided, running that: $1"
+        "${1}"
+    else
+        echo "ACCOUNT_ID: $ACCOUNT_ID"
+        associate_oidc_provider
+        create_role
+        aws iam attach-role-policy --role-name "${ROLE_NAME}" --policy-arn "${S3_POLICY_ARN}"
+        annotate_serviceaccount
+        checkit
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Helper/POC script demonstrating how to associate a role with the default service account in the `default` namespace granting read-only access to an s3 bucket.

Usage:

```
$ ./bin/sa-can-read-s3.sh 
ACCOUNT_ID: 526226851802
[ℹ]  eksctl version 0.32.0
[ℹ]  using region eu-north-1
[ℹ]  IAM Open ID Connect provider is already associated with cluster "floral-mongoose-1616851817" in "eu-north-1"
Role service-account-role already exists
serviceaccount/default annotated
Will try to read s3://wooga-booga-pants/top-sekret.txt
If you don't see a command prompt, try pressing enter.
THE UNICORN IS IN THE GARDEN!!
pod "can-we-read-s3" deleted
```