### PR TITLE
fix(594): remove trailing slash from volumes def

### DIFF
--- a/dockercoins/docker-compose.yml
+++ b/dockercoins/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     ports:
     - "8000:80"
     volumes:
-    - "./webui/files/:/files/"
+    - "./webui/files:/files"
 
   redis:
     image: redis


### PR DESCRIPTION
Fixes dockercoins demo for Windows WSL2/ubuntu.

Tested: manually, on WSL2/ubuntu only.

#594