### PR TITLE
Update link to the PersistentVolumeClaimBinder design doc

### DIFF
--- a/slides/k8s/pv-pvc-sc.md
+++ b/slides/k8s/pv-pvc-sc.md
@@ -136,7 +136,7 @@ class: extra-details
 
   (this will associate it to the specified PVC, but only if the PV satisfies all the requirements of the PVC; otherwise another PV might end up being picked)
 
-- For all the details about the PersistentVolumeClaimBinder, check [this doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/persistent-storage.md#matching-and-binding)
+- For all the details about the PersistentVolumeClaimBinder, check [this doc](https://github.com/kubernetes/design-proposals-archive/blob/main/storage/persistent-storage.md#matching-and-binding)
 
 ---
 


### PR DESCRIPTION
It looks like that doc has been moved elsewhere. This commit updates the link to (what I think is) the intended page.