### PR TITLE
fix typo in definition of access modes

### DIFF
--- a/slides/k8s/pv-pvc-sc.md
+++ b/slides/k8s/pv-pvc-sc.md
@@ -30,9 +30,9 @@
 
   - ReadWriteOncePod (only one pod can access the volume; new in Kubernetes 1.22)
 
-- A PV lists the access modes that it requires
+- A PVC lists the access modes that it requires
 
-- A PVC lists the access modes that it supports
+- A PV lists the access modes that it supports
 
 ⚠️ A PV with only ReadWriteMany won't satisfy a PVC with ReadWriteOnce!
 


### PR DESCRIPTION
IIRC https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes it is the PVClaim that lists the access modes it requires and the PV that lists the access modes it supports.