### PR TITLE
Fixed link to Docker forums in intro.md

### DIFF
--- a/slides/containers/intro.md
+++ b/slides/containers/intro.md
@@ -13,7 +13,7 @@
 - ... Or be comfortable spending some time reading the Docker
  [documentation](https://docs.docker.com/) ...
 
-- ... And looking for answers in the [Docker forums](forums.docker.com),
+- ... And looking for answers in the [Docker forums](https://forums.docker.com),
   [StackOverflow](http://stackoverflow.com/questions/tagged/docker),
   and other outlets
 


### PR DESCRIPTION
Currently link is treated as relative, and points to https://container.training/forums.docker.com