### PR TITLE
helm intro set value to juice-shop chart

### DIFF
--- a/slides/k8s/helm-intro.md
+++ b/slides/k8s/helm-intro.md
@@ -504,7 +504,7 @@ The `readme` may or may not have (accurate) explanations for the values.
 
 - Update `my-juice-shop`:
   ```bash
-  helm upgrade my-juice-shop juice/my-juice-shop \
+  helm upgrade my-juice-shop juice/juice-shop \
        --set service.type=NodePort
   ```
 


### PR DESCRIPTION
The chart was installed as juice/juice-shop, not juice/my-juice-shop. Command was failing.

Thanks