### PR TITLE
Check for missing docker dir

### DIFF
--- a/prepare-vms/lib/commands.sh
+++ b/prepare-vms/lib/commands.sh
@@ -267,6 +267,7 @@ _cmd_docker() {
 
     # Add registry mirror configuration.
     if ! [ -f /etc/docker/daemon.json ]; then
+    	sudo mkdir -p /etc/docker
         echo '{\"registry-mirrors\": [\"https://mirror.gcr.io\"]}' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
     fi

--- a/prepare-vms/lib/commands.sh
+++ b/prepare-vms/lib/commands.sh
@@ -267,7 +267,7 @@ _cmd_docker() {
 
     # Add registry mirror configuration.
     if ! [ -f /etc/docker/daemon.json ]; then
-    	sudo mkdir -p /etc/docker
+        sudo mkdir -p /etc/docker
         echo '{\"registry-mirrors\": [\"https://mirror.gcr.io\"]}' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
     fi


### PR DESCRIPTION
Docker v23 no longer creates the `/etc/docker/` directory, so we need to create it and don't error if it already exists (for older versions).