### PR TITLE
fix PuTTY link in handson.md

### DIFF
--- a/slides/shared/handson.md
+++ b/slides/shared/handson.md
@@ -110,7 +110,7 @@ class: in-person
 
 - On Windows, get one of these:
 
-  - [putty](http://www.putty.org/)
+  - [putty](https://putty.software/)
   - Microsoft [Win32 OpenSSH](https://github.com/PowerShell/Win32-OpenSSH/wiki/Install-Win32-OpenSSH)
   - [Git BASH](https://git-for-windows.github.io/)
   - [MobaXterm](http://mobaxterm.mobatek.net/)


### PR DESCRIPTION
The link to PuTTY was pointing to putty.org. This domain has no relation to the PuTTY project! Instead, the website run by the actual PuTTY team can be found under https://putty.software , see https://hachyderm.io/@simontatham/115025974777386803