### PR TITLE
prepare-labs: bump kustomize to v5.8.1

### DIFF
--- a/prepare-labs/lib/commands.sh
+++ b/prepare-labs/lib/commands.sh
@@ -819,7 +819,7 @@ EOF
 
     # Install kustomize
     ##VERSION## https://github.com/kubernetes-sigs/kustomize/releases
-    KUSTOMIZE_VERSION=v5.4.1
+    KUSTOMIZE_VERSION=v5.8.1
     URL=\$GITHUB/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
     pssh "
     if [ ! -x /usr/local/bin/kustomize ]; then


### PR DESCRIPTION
Hi @jpetazzo :wave: 

This PR bumps the Kustomize version from `5.4.1` to `5.8.1` to keep the lab environments up to date.

**Changes**
- Updated Kustomize version to v5.8.1.

tchus !